### PR TITLE
use regex in literalParts

### DIFF
--- a/dist/browser/eyeling.browser.js
+++ b/dist/browser/eyeling.browser.js
@@ -11057,13 +11057,14 @@ ${triples.map((tr) => `  ${tripleToN3(tr, prefixes)}`).join('\n')}
       // Also strip an optional language tag from the lexical form:
       //   "\"hello\"@en"  -> "\"hello\""
       //   "\"hello\"@en^^<...>" is rejected earlier in the parser.
-      const idx = lit.indexOf('^^');
       let lex = lit;
       let dt = null;
 
-      if (idx >= 0) {
-        lex = lit.slice(0, idx);
-        dt = lit.slice(idx + 2).trim();
+      const re = /^(['"]{1,3})([\s\S]*?)\1\^\^(.+)$/;
+      const match = lit.match(re);
+      if (match) {
+        lex = match[1] + match[2] + match[1];
+        dt = match[3];
         if (dt.startsWith('<') && dt.endsWith('>')) {
           dt = dt.slice(1, -1);
         }

--- a/eyeling.js
+++ b/eyeling.js
@@ -11028,13 +11028,14 @@ function literalParts(lit) {
   // Also strip an optional language tag from the lexical form:
   //   "\"hello\"@en"  -> "\"hello\""
   //   "\"hello\"@en^^<...>" is rejected earlier in the parser.
-  const idx = lit.indexOf('^^');
   let lex = lit;
   let dt = null;
 
-  if (idx >= 0) {
-    lex = lit.slice(0, idx);
-    dt = lit.slice(idx + 2).trim();
+  const re = /^(['"]{1,3})([\s\S]*?)\1\^\^(.+)$/;
+  const match = lit.match(re);
+  if (match) {
+    lex = match[1] + match[2] + match[1];
+    dt = match[3];
     if (dt.startsWith('<') && dt.endsWith('>')) {
       dt = dt.slice(1, -1);
     }

--- a/lib/prelude.js
+++ b/lib/prelude.js
@@ -57,13 +57,14 @@ function literalParts(lit) {
   // Also strip an optional language tag from the lexical form:
   //   "\"hello\"@en"  -> "\"hello\""
   //   "\"hello\"@en^^<...>" is rejected earlier in the parser.
-  const idx = lit.indexOf('^^');
   let lex = lit;
   let dt = null;
 
-  if (idx >= 0) {
-    lex = lit.slice(0, idx);
-    dt = lit.slice(idx + 2).trim();
+  const re = /^(['"]{1,3})([\s\S]*?)\1\^\^(.+)$/;
+  const match = lit.match(re);
+  if (match) {
+    lex = match[1] + match[2] + match[1];
+    dt = match[3];
     if (dt.startsWith('<') && dt.endsWith('>')) {
       dt = dt.slice(1, -1);
     }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -259,6 +259,35 @@ ${U('c')} ${U('friend')} ${U('d')}.
 
 const cases = [
   {
+    name: '00 parsing untyped literal ^^',
+    opt: { proofComments: false },
+    input: `
+  @prefix : <http://example.org/> .
+  @prefix log: <http://www.w3.org/2000/10/swap/log#>.
+
+  { ?s :p ?o } => { ?s log:outputString ?o } .
+  :s :p "^^" .
+  `,
+    check(out) {
+      assert.equal(String(out).trimEnd(), '^^');
+    },
+  },
+  {
+    name: '00b parsing typed literal ^^',
+    opt: { proofComments: false },
+    input: `
+  @prefix : <http://example.org/> .
+  @prefix log: <http://www.w3.org/2000/10/swap/log#>.
+  @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+  { ?s :p ?o } => { ?s log:outputString ?o } .
+  :s :p "^^"^^xsd:string .
+  `,
+    check(out) {
+      assert.equal(String(out).trimEnd(), '^^');
+    },
+  },
+  {
     name: '01 forward rule: p -> q',
     opt: { proofComments: false },
     input: `


### PR DESCRIPTION
`literalParts`  split a literal on `^^` also when the double hat is part of the literal text.
We may use a regex to solve the issue
