### PR TITLE
Compliance tests to RDF1.2 added

### DIFF
--- a/.github/workflows/rdf12-compliance.yml
+++ b/.github/workflows/rdf12-compliance.yml
@@ -1,0 +1,27 @@
+name: RDF 1.2 Compliance
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rdf12-spec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Run RDF 1.2 spec tests
+        run: npm run rdf12

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 package-lock.json
 node_modules/
+.rdf-test-suite-cache/

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     "postversion": "git push origin HEAD --follow-tags",
     "test:stream-messages": "node test/stream_messages.test.js",
     "rdf12": "npm run rdf-12-turtle && npm run rdf-12-ntriples && npm run rdf-12-nquads && npm run rdf-12-trig",
-    "rdf-12-ntriples": "rdf-test-suite spec/parser.js https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax/manifest.ttl -i '{ \"format\": \"n-triples\" }' -c .rdf-test-suite-cache/",
-    "rdf-12-nquads": "rdf-test-suite spec/parser.js https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-quads/syntax/manifest.ttl -i '{ \"format\": \"n-quads\" }' -c .rdf-test-suite-cache/",
-    "rdf-12-turtle": "rdf-test-suite spec/parser.js https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax/manifest.ttl -i '{ \"format\": \"turtle\" }' -c .rdf-test-suite-cache/",
-    "rdf-12-trig": "rdf-test-suite spec/parser.js https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax/manifest.ttl -i '{ \"format\": \"trig\" }' -c .rdf-test-suite-cache/"
+    "rdf-12-ntriples": "rdf-test-suite spec/rdf12-parser.js https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax/manifest.ttl -i '{ \"format\": \"n-triples\" }' -c .rdf-test-suite-cache/",
+    "rdf-12-nquads": "rdf-test-suite spec/rdf12-parser.js https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-quads/syntax/manifest.ttl -i '{ \"format\": \"n-quads\" }' -c .rdf-test-suite-cache/",
+    "rdf-12-turtle": "rdf-test-suite spec/rdf12-parser.js https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax/manifest.ttl -i '{ \"format\": \"turtle\" }' -c .rdf-test-suite-cache/",
+    "rdf-12-trig": "rdf-test-suite spec/rdf12-parser.js https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax/manifest.ttl -i '{ \"format\": \"trig\" }' -c .rdf-test-suite-cache/"
   },
   "devDependencies": {
     "rdf-test-suite": "^2.1.4"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,15 @@
     "posttest": "npm run test:package",
     "preversion": "npm test",
     "postversion": "git push origin HEAD --follow-tags",
-    "test:stream-messages": "node test/stream_messages.test.js"
+    "test:stream-messages": "node test/stream_messages.test.js",
+    "rdf12": "npm run rdf-12-turtle && npm run rdf-12-ntriples && npm run rdf-12-nquads && npm run rdf-12-trig",
+    "rdf-12-ntriples": "rdf-test-suite spec/parser.js https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/syntax/manifest.ttl -i '{ \"format\": \"n-triples\" }' -c .rdf-test-suite-cache/",
+    "rdf-12-nquads": "rdf-test-suite spec/parser.js https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-quads/syntax/manifest.ttl -i '{ \"format\": \"n-quads\" }' -c .rdf-test-suite-cache/",
+    "rdf-12-turtle": "rdf-test-suite spec/parser.js https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/syntax/manifest.ttl -i '{ \"format\": \"turtle\" }' -c .rdf-test-suite-cache/",
+    "rdf-12-trig": "rdf-test-suite spec/parser.js https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/syntax/manifest.ttl -i '{ \"format\": \"trig\" }' -c .rdf-test-suite-cache/"
+  },
+  "devDependencies": {
+    "rdf-test-suite": "^2.1.4"
   },
   "exports": {
     ".": {

--- a/spec/rdf12-parser.js
+++ b/spec/rdf12-parser.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { lex, Parser } = require('../lib/engine');
+const { internalTripleToRdfJsQuad } = require('../lib/rdfjs');
+
+// Implements the IParser interface from rdf-test-suite.
+// https://github.com/rubensworks/rdf-test-suite.js/blob/master/lib/testcase/rdfsyntax/IParser.ts
+module.exports = {
+  parse(data, baseIRI) {
+    const text = typeof data === 'string' ? data : String(data || '');
+
+    // Run lexer in RDF compatibility mode for RDF 1.2 syntax tests.
+    const tokens = lex(text, { rdf: true });
+    const parser = new Parser(tokens);
+
+    if (typeof baseIRI === 'string' && baseIRI) {
+      parser.prefixes.setBase(baseIRI);
+    }
+
+    const [, triples] = parser.parseDocument();
+
+    // rdf-test-suite expects Promise<Quad[]>.
+    return Promise.resolve(triples.map((triple) => internalTripleToRdfJsQuad(triple)));
+  },
+};


### PR DESCRIPTION
I noticed not all RDF1.2 is being parsed. I opened a PR which automatically runs the RDF1.2 compliance tests. This could be useful input for your agentic workflow to fix the problems the spec tests find