### PR TITLE
Stream forward rule solutions

### DIFF
--- a/dist/browser/eyeling.browser.js
+++ b/dist/browser/eyeling.browser.js
@@ -9542,8 +9542,23 @@ function __storePredicateMemoAnswer(entry, rawGoal, subst) {
 // So this improves reuse across repeated backward proofs without changing the
 // semantics of recursive goals.
 
+// While a forward rule streams its body, the store is pinned: the body sees the
+// facts that existed when the rule started, so a rule cannot consume its own
+// conclusions mid-enumeration and its own conclusions do not invalidate the memo.
+function __factsLimitOf(facts) {
+  return facts && typeof facts.__factsLimit === 'number' ? facts.__factsLimit : Infinity;
+}
+
+function __pinFacts(facts, limit) {
+  if (Array.isArray(facts)) __setHiddenWritable(facts, '__factsLimit', limit);
+}
+
+function __unpinFacts(facts) {
+  if (Array.isArray(facts)) __setHiddenWritable(facts, '__factsLimit', undefined);
+}
+
 function goalTableScopeVersion(facts, backRules) {
-  const factCount = Array.isArray(facts) ? facts.length : 0;
+  const factCount = Array.isArray(facts) ? Math.min(facts.length, __factsLimitOf(facts)) : 0;
   const backRuleCount = Array.isArray(backRules) ? backRules.length : 0;
   const scopedLevel = facts && typeof facts.__scopedClosureLevel === 'number' ? facts.__scopedClosureLevel : 0;
   const hasScopedSnapshot = facts && facts.__scopedSnapshot ? 1 : 0;
@@ -10116,11 +10131,25 @@ function __builtinIsSatisfiableWhenFullyUnbound(pIriVal) {
   return MATH_BUILTINS_SATISFIABLE_WHEN_FULLY_UNBOUND.has(pIriVal);
 }
 
+// With opts.onSolution the caller takes each solution as it is found and gets back
+// the count, so an answer set is never held as an array. Callers that omit it get
+// the array and behave exactly as before.
 function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxResults, opts) {
+  const onSolution = opts && typeof opts.onSolution === 'function' ? opts.onSolution : null;
   const goalTable = __canLookupGoalMemo(visited) ? __ensureGoalTable(facts, backRules) : null;
   const goalMemoKeyNow = goalTable ? __goalMemoKey(goals, subst, facts, opts) : null;
   if (goalTable && goalTable.entries.has(goalMemoKeyNow)) {
     const cached = goalTable.entries.get(goalMemoKeyNow) || [];
+    if (onSolution) {
+      const lim = typeof maxResults === 'number' && maxResults > 0 ? maxResults : Infinity;
+      let n = 0;
+      for (const sol of cached) {
+        if (n >= lim) break;
+        onSolution({ ...sol });
+        n++;
+      }
+      return n;
+    }
     const cloned = __cloneGoalSolutions(cached);
     if (typeof maxResults === 'number' && maxResults > 0 && cloned.length > maxResults)
       return cloned.slice(0, maxResults);
@@ -10134,8 +10163,16 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   // IMPORTANT: This implementation is fully iterative (no JS recursion), so
   // extremely deep backward proofs (e.g. examples/ackermann.n3) do not overflow
   // the JavaScript call stack.
-  const results = [];
+  const results = onSolution ? null : [];
   const max = typeof maxResults === 'number' && maxResults > 0 ? maxResults : Infinity;
+
+  // produced replaces results.length so the loop bounds read the same in both modes.
+  // Streaming still fills the memo while it stays under the cap, so reuse for
+  // ordinary goals is unchanged.
+  let produced = 0;
+  let memoBuf = onSolution ? [] : null;
+
+  const factsLimit = __factsLimitOf(facts);
 
   // IMPORTANT: Goal reordering / deferral is only enabled when explicitly
   // requested by the caller (used for forward rules).
@@ -10152,12 +10189,32 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     for (const v of opts.keepVars) answerVars.add(v);
   }
 
-  if (!initialGoals.length) {
-    results.push(gcCompactForGoals(substMut, [], answerVars));
-    if (goalTable && __canStoreGoalMemo(visited, maxResults, results.length)) {
-      goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(results));
+  function emitSolution() {
+    const sol = gcCompactForGoals(substMut, [], answerVars);
+    produced++;
+    if (!onSolution) {
+      results.push(sol);
+      return;
     }
-    return results;
+    if (memoBuf) {
+      if (memoBuf.length < GOAL_MEMO_MAX_ANSWERS) memoBuf.push(sol);
+      else memoBuf = null;
+    }
+    onSolution(sol);
+  }
+
+  // Returns the solution array, or the count when streaming.
+  function finish() {
+    const collected = onSolution ? memoBuf : results;
+    if (goalTable && collected && __canStoreGoalMemo(visited, maxResults, collected.length)) {
+      goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(collected));
+    }
+    return onSolution ? produced : results;
+  }
+
+  if (!initialGoals.length) {
+    emitSolution();
+    return finish();
   }
 
   // Trail of variable names that were newly bound in substMut.
@@ -10438,7 +10495,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     deferCount: 0,
   });
 
-  while (stack.length && results.length < max) {
+  while (stack.length && produced < max) {
     const frame = stack.pop();
 
     if (frame.kind === 'undo') {
@@ -10459,7 +10516,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
 
     if (frame.kind === 'memoAnswerIter') {
       const answers = frame.entry.answers;
-      while (frame.idx < answers.length && results.length < max) {
+      while (frame.idx < answers.length && produced < max) {
         const answer = answers[frame.idx++];
         const mark = trail.length;
         if (!unifyTripleTrail(frame.goal0, answer)) {
@@ -10468,9 +10525,9 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
         }
 
         if (!frame.restGoals.length) {
-          results.push(gcCompactForGoals(substMut, [], answerVars));
+          emitSolution();
           undoTo(mark);
-          if (results.length >= max) return results;
+          if (produced >= max) return finish();
           continue;
         }
 
@@ -10490,7 +10547,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
 
     if (frame.kind === 'deltaIter') {
       const deltas = frame.deltas;
-      while (frame.idx < deltas.length && results.length < max) {
+      while (frame.idx < deltas.length && produced < max) {
         const delta = deltas[frame.idx++];
         const mark = trail.length;
         if (!applyDeltaToSubst(delta)) {
@@ -10499,9 +10556,9 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
         }
 
         if (!frame.restGoals.length) {
-          results.push(gcCompactForGoals(substMut, [], answerVars));
+          emitSolution();
           undoTo(mark);
-          if (results.length >= max) return results;
+          if (produced >= max) return finish();
           continue;
         }
 
@@ -10522,7 +10579,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
 
     if (frame.kind === 'ruleIter') {
       const rules = frame.rules;
-      while (frame.idx < rules.length && results.length < max) {
+      while (frame.idx < rules.length && produced < max) {
         const r = rules[frame.idx++];
         if (r.conclusion.length !== 1) continue;
         const rawHead = r.conclusion[0];
@@ -10582,12 +10639,15 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
       const candidates = frame.candidates;
       const isIndexed = !!candidates;
 
-      while (frame.idx < (isIndexed ? candidates.totalLen : factsList.length) && results.length < max) {
+      const iterLen = isIndexed ? candidates.totalLen : Math.min(factsList.length, factsLimit);
+
+      while (frame.idx < iterLen && produced < max) {
         let f;
         if (isIndexed) {
           const idxNow = frame.idx++;
-          if (idxNow < candidates.exactLen) f = factsList[candidates.exact[idxNow]];
-          else f = factsList[candidates.wild[idxNow - candidates.exactLen]];
+          const pos = idxNow < candidates.exactLen ? candidates.exact[idxNow] : candidates.wild[idxNow - candidates.exactLen];
+          if (pos >= factsLimit) continue;
+          f = factsList[pos];
         } else {
           f = factsList[frame.idx++];
         }
@@ -10599,9 +10659,9 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
         }
 
         if (!frame.restGoals.length) {
-          results.push(gcCompactForGoals(substMut, [], answerVars));
+          emitSolution();
           undoTo(mark);
-          if (results.length >= max) return results;
+          if (produced >= max) return finish();
           continue;
         }
 
@@ -10624,7 +10684,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     // frame.kind === 'node'
     const goalsNow = frame.goalsNow;
     if (!goalsNow.length) {
-      results.push(gcCompactForGoals(substMut, [], answerVars));
+      emitSolution();
       continue;
     }
 
@@ -10657,7 +10717,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
       );
 
     if (shouldTreatAsBuiltin) {
-      const remaining = max - results.length;
+      const remaining = max - produced;
       if (remaining <= 0) continue;
       const builtinMax = Number.isFinite(remaining) && !restGoals.length ? remaining : undefined;
 
@@ -10826,11 +10886,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     }
   }
 
-  if (goalTable && __canStoreGoalMemo(visited, maxResults, results.length)) {
-    goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(results));
-  }
-
-  return results;
+  return finish();
 }
 
 
@@ -11318,17 +11374,22 @@ function forwardChain(facts, forwardRules, backRules, onDerived /* optional */, 
           // This keeps forward-chaining conjunctions order-insensitive while
           // preserving left-to-right evaluation inside backward rules (<=),
           // which is important for termination on some programs (e.g., dijkstra).
-          const sols = proveGoals(r.premise, null, facts, backRules, 0, null, varGen, maxSols, {
-            deferBuiltins: true,
-          });
+          const proveOpts = { deferBuiltins: true };
 
-          // Inference fuse
-          if (r.isFuse && sols.length) {
-            __printTriggeredFuse(r, opts && opts.prefixes, sols[0]);
-            __exitReasoning(INFERENCE_FUSE_EXIT_CODE, 'Inference fuse triggered.');
+          // A fuse only needs to know that the body holds, and it reports the
+          // witness, so it keeps the array path — maxSols is 1.
+          if (r.isFuse) {
+            const sols = proveGoals(r.premise, null, facts, backRules, 0, null, varGen, maxSols, proveOpts);
+            if (sols.length) {
+              __printTriggeredFuse(r, opts && opts.prefixes, sols[0]);
+              __exitReasoning(INFERENCE_FUSE_EXIT_CODE, 'Inference fuse triggered.');
+            }
+            continue;
           }
 
-          for (const s of sols) {
+          // Stream the body: a rule's peak is the closure plus one substitution
+          // instead of the closure plus every substitution the body admits.
+          proveOpts.onSolution = (s) => {
             const outcome = __emitForwardRuleSolution(r, i, s);
             if (outcome.rulesChanged) {
               maxScopedClosurePriorityNeeded = Math.max(
@@ -11342,6 +11403,12 @@ function forwardChain(facts, forwardRules, backRules, onDerived /* optional */, 
               changed = true;
               anyChange = true;
             }
+          };
+          __pinFacts(facts, facts.length);
+          try {
+            proveGoals(r.premise, null, facts, backRules, 0, null, varGen, maxSols, proveOpts);
+          } finally {
+            __unpinFacts(facts);
           }
         }
 

--- a/dist/browser/eyeling.browser.js
+++ b/dist/browser/eyeling.browser.js
@@ -9606,7 +9606,12 @@ function __canLookupGoalMemo(visited) {
   return !visited || visited.length === 0;
 }
 
-function __canStoreGoalMemo(visited, maxResults) {
+// __cloneGoalSolutions copies the whole array, so memoising a very large answer
+// set doubles the peak for reuse no rule body realistically gets.
+const GOAL_MEMO_MAX_ANSWERS = 100000;
+
+function __canStoreGoalMemo(visited, maxResults, answerCount) {
+  if (typeof answerCount === 'number' && answerCount > GOAL_MEMO_MAX_ANSWERS) return false;
   return (!visited || visited.length === 0) && !(typeof maxResults === 'number' && maxResults > 0);
 }
 
@@ -10149,7 +10154,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
 
   if (!initialGoals.length) {
     results.push(gcCompactForGoals(substMut, [], answerVars));
-    if (goalTable && __canStoreGoalMemo(visited, maxResults)) {
+    if (goalTable && __canStoreGoalMemo(visited, maxResults, results.length)) {
       goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(results));
     }
     return results;
@@ -10821,7 +10826,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     }
   }
 
-  if (goalTable && __canStoreGoalMemo(visited, maxResults)) {
+  if (goalTable && __canStoreGoalMemo(visited, maxResults, results.length)) {
     goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(results));
   }
 

--- a/eyeling.js
+++ b/eyeling.js
@@ -9542,8 +9542,23 @@ function __storePredicateMemoAnswer(entry, rawGoal, subst) {
 // So this improves reuse across repeated backward proofs without changing the
 // semantics of recursive goals.
 
+// While a forward rule streams its body, the store is pinned: the body sees the
+// facts that existed when the rule started, so a rule cannot consume its own
+// conclusions mid-enumeration and its own conclusions do not invalidate the memo.
+function __factsLimitOf(facts) {
+  return facts && typeof facts.__factsLimit === 'number' ? facts.__factsLimit : Infinity;
+}
+
+function __pinFacts(facts, limit) {
+  if (Array.isArray(facts)) __setHiddenWritable(facts, '__factsLimit', limit);
+}
+
+function __unpinFacts(facts) {
+  if (Array.isArray(facts)) __setHiddenWritable(facts, '__factsLimit', undefined);
+}
+
 function goalTableScopeVersion(facts, backRules) {
-  const factCount = Array.isArray(facts) ? facts.length : 0;
+  const factCount = Array.isArray(facts) ? Math.min(facts.length, __factsLimitOf(facts)) : 0;
   const backRuleCount = Array.isArray(backRules) ? backRules.length : 0;
   const scopedLevel = facts && typeof facts.__scopedClosureLevel === 'number' ? facts.__scopedClosureLevel : 0;
   const hasScopedSnapshot = facts && facts.__scopedSnapshot ? 1 : 0;
@@ -10116,11 +10131,25 @@ function __builtinIsSatisfiableWhenFullyUnbound(pIriVal) {
   return MATH_BUILTINS_SATISFIABLE_WHEN_FULLY_UNBOUND.has(pIriVal);
 }
 
+// With opts.onSolution the caller takes each solution as it is found and gets back
+// the count, so an answer set is never held as an array. Callers that omit it get
+// the array and behave exactly as before.
 function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxResults, opts) {
+  const onSolution = opts && typeof opts.onSolution === 'function' ? opts.onSolution : null;
   const goalTable = __canLookupGoalMemo(visited) ? __ensureGoalTable(facts, backRules) : null;
   const goalMemoKeyNow = goalTable ? __goalMemoKey(goals, subst, facts, opts) : null;
   if (goalTable && goalTable.entries.has(goalMemoKeyNow)) {
     const cached = goalTable.entries.get(goalMemoKeyNow) || [];
+    if (onSolution) {
+      const lim = typeof maxResults === 'number' && maxResults > 0 ? maxResults : Infinity;
+      let n = 0;
+      for (const sol of cached) {
+        if (n >= lim) break;
+        onSolution({ ...sol });
+        n++;
+      }
+      return n;
+    }
     const cloned = __cloneGoalSolutions(cached);
     if (typeof maxResults === 'number' && maxResults > 0 && cloned.length > maxResults)
       return cloned.slice(0, maxResults);
@@ -10134,8 +10163,16 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   // IMPORTANT: This implementation is fully iterative (no JS recursion), so
   // extremely deep backward proofs (e.g. examples/ackermann.n3) do not overflow
   // the JavaScript call stack.
-  const results = [];
+  const results = onSolution ? null : [];
   const max = typeof maxResults === 'number' && maxResults > 0 ? maxResults : Infinity;
+
+  // produced replaces results.length so the loop bounds read the same in both modes.
+  // Streaming still fills the memo while it stays under the cap, so reuse for
+  // ordinary goals is unchanged.
+  let produced = 0;
+  let memoBuf = onSolution ? [] : null;
+
+  const factsLimit = __factsLimitOf(facts);
 
   // IMPORTANT: Goal reordering / deferral is only enabled when explicitly
   // requested by the caller (used for forward rules).
@@ -10152,12 +10189,32 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     for (const v of opts.keepVars) answerVars.add(v);
   }
 
-  if (!initialGoals.length) {
-    results.push(gcCompactForGoals(substMut, [], answerVars));
-    if (goalTable && __canStoreGoalMemo(visited, maxResults, results.length)) {
-      goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(results));
+  function emitSolution() {
+    const sol = gcCompactForGoals(substMut, [], answerVars);
+    produced++;
+    if (!onSolution) {
+      results.push(sol);
+      return;
     }
-    return results;
+    if (memoBuf) {
+      if (memoBuf.length < GOAL_MEMO_MAX_ANSWERS) memoBuf.push(sol);
+      else memoBuf = null;
+    }
+    onSolution(sol);
+  }
+
+  // Returns the solution array, or the count when streaming.
+  function finish() {
+    const collected = onSolution ? memoBuf : results;
+    if (goalTable && collected && __canStoreGoalMemo(visited, maxResults, collected.length)) {
+      goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(collected));
+    }
+    return onSolution ? produced : results;
+  }
+
+  if (!initialGoals.length) {
+    emitSolution();
+    return finish();
   }
 
   // Trail of variable names that were newly bound in substMut.
@@ -10438,7 +10495,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     deferCount: 0,
   });
 
-  while (stack.length && results.length < max) {
+  while (stack.length && produced < max) {
     const frame = stack.pop();
 
     if (frame.kind === 'undo') {
@@ -10459,7 +10516,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
 
     if (frame.kind === 'memoAnswerIter') {
       const answers = frame.entry.answers;
-      while (frame.idx < answers.length && results.length < max) {
+      while (frame.idx < answers.length && produced < max) {
         const answer = answers[frame.idx++];
         const mark = trail.length;
         if (!unifyTripleTrail(frame.goal0, answer)) {
@@ -10468,9 +10525,9 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
         }
 
         if (!frame.restGoals.length) {
-          results.push(gcCompactForGoals(substMut, [], answerVars));
+          emitSolution();
           undoTo(mark);
-          if (results.length >= max) return results;
+          if (produced >= max) return finish();
           continue;
         }
 
@@ -10490,7 +10547,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
 
     if (frame.kind === 'deltaIter') {
       const deltas = frame.deltas;
-      while (frame.idx < deltas.length && results.length < max) {
+      while (frame.idx < deltas.length && produced < max) {
         const delta = deltas[frame.idx++];
         const mark = trail.length;
         if (!applyDeltaToSubst(delta)) {
@@ -10499,9 +10556,9 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
         }
 
         if (!frame.restGoals.length) {
-          results.push(gcCompactForGoals(substMut, [], answerVars));
+          emitSolution();
           undoTo(mark);
-          if (results.length >= max) return results;
+          if (produced >= max) return finish();
           continue;
         }
 
@@ -10522,7 +10579,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
 
     if (frame.kind === 'ruleIter') {
       const rules = frame.rules;
-      while (frame.idx < rules.length && results.length < max) {
+      while (frame.idx < rules.length && produced < max) {
         const r = rules[frame.idx++];
         if (r.conclusion.length !== 1) continue;
         const rawHead = r.conclusion[0];
@@ -10582,12 +10639,15 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
       const candidates = frame.candidates;
       const isIndexed = !!candidates;
 
-      while (frame.idx < (isIndexed ? candidates.totalLen : factsList.length) && results.length < max) {
+      const iterLen = isIndexed ? candidates.totalLen : Math.min(factsList.length, factsLimit);
+
+      while (frame.idx < iterLen && produced < max) {
         let f;
         if (isIndexed) {
           const idxNow = frame.idx++;
-          if (idxNow < candidates.exactLen) f = factsList[candidates.exact[idxNow]];
-          else f = factsList[candidates.wild[idxNow - candidates.exactLen]];
+          const pos = idxNow < candidates.exactLen ? candidates.exact[idxNow] : candidates.wild[idxNow - candidates.exactLen];
+          if (pos >= factsLimit) continue;
+          f = factsList[pos];
         } else {
           f = factsList[frame.idx++];
         }
@@ -10599,9 +10659,9 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
         }
 
         if (!frame.restGoals.length) {
-          results.push(gcCompactForGoals(substMut, [], answerVars));
+          emitSolution();
           undoTo(mark);
-          if (results.length >= max) return results;
+          if (produced >= max) return finish();
           continue;
         }
 
@@ -10624,7 +10684,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     // frame.kind === 'node'
     const goalsNow = frame.goalsNow;
     if (!goalsNow.length) {
-      results.push(gcCompactForGoals(substMut, [], answerVars));
+      emitSolution();
       continue;
     }
 
@@ -10657,7 +10717,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
       );
 
     if (shouldTreatAsBuiltin) {
-      const remaining = max - results.length;
+      const remaining = max - produced;
       if (remaining <= 0) continue;
       const builtinMax = Number.isFinite(remaining) && !restGoals.length ? remaining : undefined;
 
@@ -10826,11 +10886,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     }
   }
 
-  if (goalTable && __canStoreGoalMemo(visited, maxResults, results.length)) {
-    goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(results));
-  }
-
-  return results;
+  return finish();
 }
 
 
@@ -11318,17 +11374,22 @@ function forwardChain(facts, forwardRules, backRules, onDerived /* optional */, 
           // This keeps forward-chaining conjunctions order-insensitive while
           // preserving left-to-right evaluation inside backward rules (<=),
           // which is important for termination on some programs (e.g., dijkstra).
-          const sols = proveGoals(r.premise, null, facts, backRules, 0, null, varGen, maxSols, {
-            deferBuiltins: true,
-          });
+          const proveOpts = { deferBuiltins: true };
 
-          // Inference fuse
-          if (r.isFuse && sols.length) {
-            __printTriggeredFuse(r, opts && opts.prefixes, sols[0]);
-            __exitReasoning(INFERENCE_FUSE_EXIT_CODE, 'Inference fuse triggered.');
+          // A fuse only needs to know that the body holds, and it reports the
+          // witness, so it keeps the array path — maxSols is 1.
+          if (r.isFuse) {
+            const sols = proveGoals(r.premise, null, facts, backRules, 0, null, varGen, maxSols, proveOpts);
+            if (sols.length) {
+              __printTriggeredFuse(r, opts && opts.prefixes, sols[0]);
+              __exitReasoning(INFERENCE_FUSE_EXIT_CODE, 'Inference fuse triggered.');
+            }
+            continue;
           }
 
-          for (const s of sols) {
+          // Stream the body: a rule's peak is the closure plus one substitution
+          // instead of the closure plus every substitution the body admits.
+          proveOpts.onSolution = (s) => {
             const outcome = __emitForwardRuleSolution(r, i, s);
             if (outcome.rulesChanged) {
               maxScopedClosurePriorityNeeded = Math.max(
@@ -11342,6 +11403,12 @@ function forwardChain(facts, forwardRules, backRules, onDerived /* optional */, 
               changed = true;
               anyChange = true;
             }
+          };
+          __pinFacts(facts, facts.length);
+          try {
+            proveGoals(r.premise, null, facts, backRules, 0, null, varGen, maxSols, proveOpts);
+          } finally {
+            __unpinFacts(facts);
           }
         }
 

--- a/eyeling.js
+++ b/eyeling.js
@@ -9606,7 +9606,12 @@ function __canLookupGoalMemo(visited) {
   return !visited || visited.length === 0;
 }
 
-function __canStoreGoalMemo(visited, maxResults) {
+// __cloneGoalSolutions copies the whole array, so memoising a very large answer
+// set doubles the peak for reuse no rule body realistically gets.
+const GOAL_MEMO_MAX_ANSWERS = 100000;
+
+function __canStoreGoalMemo(visited, maxResults, answerCount) {
+  if (typeof answerCount === 'number' && answerCount > GOAL_MEMO_MAX_ANSWERS) return false;
   return (!visited || visited.length === 0) && !(typeof maxResults === 'number' && maxResults > 0);
 }
 
@@ -10149,7 +10154,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
 
   if (!initialGoals.length) {
     results.push(gcCompactForGoals(substMut, [], answerVars));
-    if (goalTable && __canStoreGoalMemo(visited, maxResults)) {
+    if (goalTable && __canStoreGoalMemo(visited, maxResults, results.length)) {
       goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(results));
     }
     return results;
@@ -10821,7 +10826,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     }
   }
 
-  if (goalTable && __canStoreGoalMemo(visited, maxResults)) {
+  if (goalTable && __canStoreGoalMemo(visited, maxResults, results.length)) {
     goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(results));
   }
 

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -2123,7 +2123,12 @@ function __canLookupGoalMemo(visited) {
   return !visited || visited.length === 0;
 }
 
-function __canStoreGoalMemo(visited, maxResults) {
+// __cloneGoalSolutions copies the whole array, so memoising a very large answer
+// set doubles the peak for reuse no rule body realistically gets.
+const GOAL_MEMO_MAX_ANSWERS = 100000;
+
+function __canStoreGoalMemo(visited, maxResults, answerCount) {
+  if (typeof answerCount === 'number' && answerCount > GOAL_MEMO_MAX_ANSWERS) return false;
   return (!visited || visited.length === 0) && !(typeof maxResults === 'number' && maxResults > 0);
 }
 
@@ -2666,7 +2671,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
 
   if (!initialGoals.length) {
     results.push(gcCompactForGoals(substMut, [], answerVars));
-    if (goalTable && __canStoreGoalMemo(visited, maxResults)) {
+    if (goalTable && __canStoreGoalMemo(visited, maxResults, results.length)) {
       goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(results));
     }
     return results;
@@ -3338,7 +3343,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     }
   }
 
-  if (goalTable && __canStoreGoalMemo(visited, maxResults)) {
+  if (goalTable && __canStoreGoalMemo(visited, maxResults, results.length)) {
     goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(results));
   }
 

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -2059,8 +2059,23 @@ function __storePredicateMemoAnswer(entry, rawGoal, subst) {
 // So this improves reuse across repeated backward proofs without changing the
 // semantics of recursive goals.
 
+// While a forward rule streams its body, the store is pinned: the body sees the
+// facts that existed when the rule started, so a rule cannot consume its own
+// conclusions mid-enumeration and its own conclusions do not invalidate the memo.
+function __factsLimitOf(facts) {
+  return facts && typeof facts.__factsLimit === 'number' ? facts.__factsLimit : Infinity;
+}
+
+function __pinFacts(facts, limit) {
+  if (Array.isArray(facts)) __setHiddenWritable(facts, '__factsLimit', limit);
+}
+
+function __unpinFacts(facts) {
+  if (Array.isArray(facts)) __setHiddenWritable(facts, '__factsLimit', undefined);
+}
+
 function goalTableScopeVersion(facts, backRules) {
-  const factCount = Array.isArray(facts) ? facts.length : 0;
+  const factCount = Array.isArray(facts) ? Math.min(facts.length, __factsLimitOf(facts)) : 0;
   const backRuleCount = Array.isArray(backRules) ? backRules.length : 0;
   const scopedLevel = facts && typeof facts.__scopedClosureLevel === 'number' ? facts.__scopedClosureLevel : 0;
   const hasScopedSnapshot = facts && facts.__scopedSnapshot ? 1 : 0;
@@ -2633,11 +2648,25 @@ function __builtinIsSatisfiableWhenFullyUnbound(pIriVal) {
   return MATH_BUILTINS_SATISFIABLE_WHEN_FULLY_UNBOUND.has(pIriVal);
 }
 
+// With opts.onSolution the caller takes each solution as it is found and gets back
+// the count, so an answer set is never held as an array. Callers that omit it get
+// the array and behave exactly as before.
 function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxResults, opts) {
+  const onSolution = opts && typeof opts.onSolution === 'function' ? opts.onSolution : null;
   const goalTable = __canLookupGoalMemo(visited) ? __ensureGoalTable(facts, backRules) : null;
   const goalMemoKeyNow = goalTable ? __goalMemoKey(goals, subst, facts, opts) : null;
   if (goalTable && goalTable.entries.has(goalMemoKeyNow)) {
     const cached = goalTable.entries.get(goalMemoKeyNow) || [];
+    if (onSolution) {
+      const lim = typeof maxResults === 'number' && maxResults > 0 ? maxResults : Infinity;
+      let n = 0;
+      for (const sol of cached) {
+        if (n >= lim) break;
+        onSolution({ ...sol });
+        n++;
+      }
+      return n;
+    }
     const cloned = __cloneGoalSolutions(cached);
     if (typeof maxResults === 'number' && maxResults > 0 && cloned.length > maxResults)
       return cloned.slice(0, maxResults);
@@ -2651,8 +2680,16 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   // IMPORTANT: This implementation is fully iterative (no JS recursion), so
   // extremely deep backward proofs (e.g. examples/ackermann.n3) do not overflow
   // the JavaScript call stack.
-  const results = [];
+  const results = onSolution ? null : [];
   const max = typeof maxResults === 'number' && maxResults > 0 ? maxResults : Infinity;
+
+  // produced replaces results.length so the loop bounds read the same in both modes.
+  // Streaming still fills the memo while it stays under the cap, so reuse for
+  // ordinary goals is unchanged.
+  let produced = 0;
+  let memoBuf = onSolution ? [] : null;
+
+  const factsLimit = __factsLimitOf(facts);
 
   // IMPORTANT: Goal reordering / deferral is only enabled when explicitly
   // requested by the caller (used for forward rules).
@@ -2669,12 +2706,32 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     for (const v of opts.keepVars) answerVars.add(v);
   }
 
-  if (!initialGoals.length) {
-    results.push(gcCompactForGoals(substMut, [], answerVars));
-    if (goalTable && __canStoreGoalMemo(visited, maxResults, results.length)) {
-      goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(results));
+  function emitSolution() {
+    const sol = gcCompactForGoals(substMut, [], answerVars);
+    produced++;
+    if (!onSolution) {
+      results.push(sol);
+      return;
     }
-    return results;
+    if (memoBuf) {
+      if (memoBuf.length < GOAL_MEMO_MAX_ANSWERS) memoBuf.push(sol);
+      else memoBuf = null;
+    }
+    onSolution(sol);
+  }
+
+  // Returns the solution array, or the count when streaming.
+  function finish() {
+    const collected = onSolution ? memoBuf : results;
+    if (goalTable && collected && __canStoreGoalMemo(visited, maxResults, collected.length)) {
+      goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(collected));
+    }
+    return onSolution ? produced : results;
+  }
+
+  if (!initialGoals.length) {
+    emitSolution();
+    return finish();
   }
 
   // Trail of variable names that were newly bound in substMut.
@@ -2955,7 +3012,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     deferCount: 0,
   });
 
-  while (stack.length && results.length < max) {
+  while (stack.length && produced < max) {
     const frame = stack.pop();
 
     if (frame.kind === 'undo') {
@@ -2976,7 +3033,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
 
     if (frame.kind === 'memoAnswerIter') {
       const answers = frame.entry.answers;
-      while (frame.idx < answers.length && results.length < max) {
+      while (frame.idx < answers.length && produced < max) {
         const answer = answers[frame.idx++];
         const mark = trail.length;
         if (!unifyTripleTrail(frame.goal0, answer)) {
@@ -2985,9 +3042,9 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
         }
 
         if (!frame.restGoals.length) {
-          results.push(gcCompactForGoals(substMut, [], answerVars));
+          emitSolution();
           undoTo(mark);
-          if (results.length >= max) return results;
+          if (produced >= max) return finish();
           continue;
         }
 
@@ -3007,7 +3064,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
 
     if (frame.kind === 'deltaIter') {
       const deltas = frame.deltas;
-      while (frame.idx < deltas.length && results.length < max) {
+      while (frame.idx < deltas.length && produced < max) {
         const delta = deltas[frame.idx++];
         const mark = trail.length;
         if (!applyDeltaToSubst(delta)) {
@@ -3016,9 +3073,9 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
         }
 
         if (!frame.restGoals.length) {
-          results.push(gcCompactForGoals(substMut, [], answerVars));
+          emitSolution();
           undoTo(mark);
-          if (results.length >= max) return results;
+          if (produced >= max) return finish();
           continue;
         }
 
@@ -3039,7 +3096,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
 
     if (frame.kind === 'ruleIter') {
       const rules = frame.rules;
-      while (frame.idx < rules.length && results.length < max) {
+      while (frame.idx < rules.length && produced < max) {
         const r = rules[frame.idx++];
         if (r.conclusion.length !== 1) continue;
         const rawHead = r.conclusion[0];
@@ -3099,12 +3156,15 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
       const candidates = frame.candidates;
       const isIndexed = !!candidates;
 
-      while (frame.idx < (isIndexed ? candidates.totalLen : factsList.length) && results.length < max) {
+      const iterLen = isIndexed ? candidates.totalLen : Math.min(factsList.length, factsLimit);
+
+      while (frame.idx < iterLen && produced < max) {
         let f;
         if (isIndexed) {
           const idxNow = frame.idx++;
-          if (idxNow < candidates.exactLen) f = factsList[candidates.exact[idxNow]];
-          else f = factsList[candidates.wild[idxNow - candidates.exactLen]];
+          const pos = idxNow < candidates.exactLen ? candidates.exact[idxNow] : candidates.wild[idxNow - candidates.exactLen];
+          if (pos >= factsLimit) continue;
+          f = factsList[pos];
         } else {
           f = factsList[frame.idx++];
         }
@@ -3116,9 +3176,9 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
         }
 
         if (!frame.restGoals.length) {
-          results.push(gcCompactForGoals(substMut, [], answerVars));
+          emitSolution();
           undoTo(mark);
-          if (results.length >= max) return results;
+          if (produced >= max) return finish();
           continue;
         }
 
@@ -3141,7 +3201,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     // frame.kind === 'node'
     const goalsNow = frame.goalsNow;
     if (!goalsNow.length) {
-      results.push(gcCompactForGoals(substMut, [], answerVars));
+      emitSolution();
       continue;
     }
 
@@ -3174,7 +3234,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
       );
 
     if (shouldTreatAsBuiltin) {
-      const remaining = max - results.length;
+      const remaining = max - produced;
       if (remaining <= 0) continue;
       const builtinMax = Number.isFinite(remaining) && !restGoals.length ? remaining : undefined;
 
@@ -3343,11 +3403,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
     }
   }
 
-  if (goalTable && __canStoreGoalMemo(visited, maxResults, results.length)) {
-    goalTable.entries.set(goalMemoKeyNow, __cloneGoalSolutions(results));
-  }
-
-  return results;
+  return finish();
 }
 
 
@@ -3835,17 +3891,22 @@ function forwardChain(facts, forwardRules, backRules, onDerived /* optional */, 
           // This keeps forward-chaining conjunctions order-insensitive while
           // preserving left-to-right evaluation inside backward rules (<=),
           // which is important for termination on some programs (e.g., dijkstra).
-          const sols = proveGoals(r.premise, null, facts, backRules, 0, null, varGen, maxSols, {
-            deferBuiltins: true,
-          });
+          const proveOpts = { deferBuiltins: true };
 
-          // Inference fuse
-          if (r.isFuse && sols.length) {
-            __printTriggeredFuse(r, opts && opts.prefixes, sols[0]);
-            __exitReasoning(INFERENCE_FUSE_EXIT_CODE, 'Inference fuse triggered.');
+          // A fuse only needs to know that the body holds, and it reports the
+          // witness, so it keeps the array path — maxSols is 1.
+          if (r.isFuse) {
+            const sols = proveGoals(r.premise, null, facts, backRules, 0, null, varGen, maxSols, proveOpts);
+            if (sols.length) {
+              __printTriggeredFuse(r, opts && opts.prefixes, sols[0]);
+              __exitReasoning(INFERENCE_FUSE_EXIT_CODE, 'Inference fuse triggered.');
+            }
+            continue;
           }
 
-          for (const s of sols) {
+          // Stream the body: a rule's peak is the closure plus one substitution
+          // instead of the closure plus every substitution the body admits.
+          proveOpts.onSolution = (s) => {
             const outcome = __emitForwardRuleSolution(r, i, s);
             if (outcome.rulesChanged) {
               maxScopedClosurePriorityNeeded = Math.max(
@@ -3859,6 +3920,12 @@ function forwardChain(facts, forwardRules, backRules, onDerived /* optional */, 
               changed = true;
               anyChange = true;
             }
+          };
+          __pinFacts(facts, facts.length);
+          try {
+            proveGoals(r.premise, null, facts, backRules, 0, null, varGen, maxSols, proveOpts);
+          } finally {
+            __unpinFacts(facts);
           }
         }
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -102,6 +102,14 @@ const EX = 'http://example.org/';
 // Helper to build a URI quickly
 const U = (path) => `<${EX}${path}>`;
 
+// Derived triples carrying `pred`, sorted, for order-independent assertions.
+const derivedWith = (out, pred) =>
+  String(out)
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.includes(` ${pred} `))
+    .sort();
+
 function parentChainN3(n) {
   // n links => n+1 nodes: n0->n1->...->nN
   let s = '';
@@ -3453,6 +3461,93 @@ MESSAGE
     },
   },
 
+  {
+    name: '247 streamed forward body: every join solution is emitted',
+    opt: { proofComments: false },
+    input: `
+@prefix : <http://example.org/> .
+
+{ ?x :b1 ?z . ?z :b2 ?y } => { ?x :a ?y } .
+
+:x1 :b1 :m1 . :x1 :b1 :m2 . :x2 :b1 :m1 .
+:m1 :b2 :y1 . :m1 :b2 :y2 . :m2 :b2 :y1 .
+`,
+    check(out) {
+      assert.deepEqual(derivedWith(out, ':a'), [
+        ':x1 :a :y1 .',
+        ':x1 :a :y2 .',
+        ':x2 :a :y1 .',
+        ':x2 :a :y2 .',
+      ]);
+    },
+  },
+  {
+    name: '248 streamed forward body: transitive closure is complete and terminates',
+    opt: { proofComments: false },
+    input: `
+@prefix : <http://example.org/> .
+
+{ ?a :p ?b . ?b :p ?c } => { ?a :p ?c } .
+
+:n1 :p :n2 . :n2 :p :n3 . :n3 :p :n4 . :n4 :p :n5 .
+`,
+    check(out) {
+      assert.deepEqual(derivedWith(out, ':p'), [
+        ':n1 :p :n3 .',
+        ':n1 :p :n4 .',
+        ':n1 :p :n5 .',
+        ':n2 :p :n4 .',
+        ':n2 :p :n5 .',
+        ':n3 :p :n5 .',
+      ]);
+    },
+  },
+  {
+    name: '249 streamed forward body: a fuse over a join still triggers (expect exit 65)',
+    opt: { proofComments: false },
+    input: `
+@prefix : <http://example.org/> .
+
+{ ?x :b1 ?z . ?z :b2 ?y } => false .
+
+:x1 :b1 :m1 .
+:m1 :b2 :y1 .
+`,
+    expectErrorCode: 65,
+  },
+  {
+    name: '250 streamed forward body: a fuse whose join has no solution does not trigger',
+    opt: { proofComments: false },
+    input: `
+@prefix : <http://example.org/> .
+
+{ ?x :b1 ?z . ?z :b2 ?y } => false .
+{ ?x :b1 ?z } => { ?x :reached ?z } .
+
+:x1 :b1 :m1 .
+:m2 :b2 :y1 .
+`,
+    check(out) {
+      assert.deepEqual(derivedWith(out, ':reached'), [':x1 :reached :m1 .']);
+    },
+  },
+  {
+    name: '251 streamed forward body: notIncludes beside a join sees the store as the rule found it',
+    opt: { proofComments: false },
+    input: `
+@prefix : <http://example.org/> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ ?x :b1 ?z . ?z :b2 ?y . ?f log:notIncludes { ?x :blocked true } } => { ?x :a ?y } .
+
+:x1 :b1 :m1 . :x2 :b1 :m1 .
+:m1 :b2 :y1 . :m1 :b2 :y2 .
+:x2 :blocked true .
+`,
+    check(out) {
+      assert.deepEqual(derivedWith(out, ':a'), [':x1 :a :y1 .', ':x1 :a :y2 .']);
+    },
+  },
   {
     name: 'API empty input returns empty output',
     opt: { proofComments: false },


### PR DESCRIPTION
This pull requests adds support to stream forward rule solutions instead of adding them into an internal array (which can case an OOM for large closures).

A freeze was added to ensure raw text equality of the test (byte-equivalence). Feeze makes sure that a rule's body sees the fact store as it was when that rule started, for the whole duration of its streaming call.