### PR TITLE
Perf duplicate check

### DIFF
--- a/dist/browser/eyeling.browser.js
+++ b/dist/browser/eyeling.browser.js
@@ -10145,6 +10145,115 @@ function __builtinIsSatisfiableWhenFullyUnbound(pIriVal) {
   return MATH_BUILTINS_SATISFIABLE_WHEN_FULLY_UNBOUND.has(pIriVal);
 }
 
+
+// Cost-gated body ordering for forward rules.
+//
+// A conjunction is evaluated left to right, so a body that opens with unselective
+// patterns enumerates their product before any shared variable can prune it. Only
+// fact-lookup goals are considered here: a goal that a backward rule could answer
+// keeps its written position, because rule selection order is load-bearing for
+// termination. The written order is kept unless the estimate says it is
+// catastrophically worse, so ordinary programs — and their output order — do not move.
+const GOAL_ORDER_MIN_GOALS = 3;
+const GOAL_ORDER_MIN_COST = 1e6;
+const GOAL_ORDER_MIN_GAIN = 100;
+
+function __orderCandidateTerm(t) {
+  return t instanceof Iri || t instanceof Literal || t instanceof Blank || t instanceof Var;
+}
+
+function __orderCandidateGoal(tr, backRules) {
+  if (!tr || !(tr.p instanceof Iri)) return false;
+  if (isBuiltinPred(tr.p)) return false;
+  if (backRules.__wildHeadPred && backRules.__wildHeadPred.length) return false;
+  if (backRules.__byHeadPred && backRules.__byHeadPred.has(tr.p.__tid)) return false;
+  return __orderCandidateTerm(tr.s) && __orderCandidateTerm(tr.o);
+}
+
+function __orderTermIsBound(term, bound) {
+  if (term instanceof Var) return bound.has(term.name);
+  if (term instanceof Blank) return bound.has(term.label);
+  return true;
+}
+
+function __orderBindTerm(term, bound) {
+  if (term instanceof Var) bound.add(term.name);
+  else if (term instanceof Blank) bound.add(term.label);
+}
+
+// Expected matches for one binding of what is already bound.
+function __orderFanout(facts, tr, bound) {
+  const pk = tr.p.__tid;
+  const all = facts.__byPred.get(pk);
+  const extent = all ? all.length : 0;
+  if (extent === 0) return 0;
+
+  const sBound = __orderTermIsBound(tr.s, bound);
+  const oBound = __orderTermIsBound(tr.o, bound);
+  let est = extent;
+  if (sBound) {
+    const byS = facts.__byPS.get(pk);
+    if (byS && byS.size) est = Math.min(est, extent / byS.size);
+  }
+  if (oBound) {
+    const byO = facts.__byPO.get(pk);
+    if (byO && byO.size) est = Math.min(est, extent / byO.size);
+  }
+  if (sBound && oBound) est = Math.min(est, 1);
+  return est;
+}
+
+function __orderCost(order, facts, boundStart) {
+  const bound = new Set(boundStart);
+  let card = 1;
+  let cost = 0;
+  for (let i = 0; i < order.length; i++) {
+    const parent = card;
+    card *= __orderFanout(facts, order[i], bound);
+    cost += Math.max(parent, card);
+    __orderBindTerm(order[i].s, bound);
+    __orderBindTerm(order[i].o, bound);
+    if (card === 0) break;
+  }
+  return cost;
+}
+
+function __reorderBodyForCost(goals, subst, facts, backRules) {
+  if (goals.length < GOAL_ORDER_MIN_GOALS) return null;
+  for (let i = 0; i < goals.length; i++) {
+    if (!__orderCandidateGoal(goals[i], backRules)) return null;
+  }
+
+  const boundStart = new Set();
+  if (subst) for (const k in subst) if (hasOwn.call(subst, k)) boundStart.add(k);
+
+  const writtenCost = __orderCost(goals, facts, boundStart);
+  if (!(writtenCost > GOAL_ORDER_MIN_COST)) return null;
+
+  const bound = new Set(boundStart);
+  const remaining = goals.slice();
+  const greedy = [];
+  while (remaining.length) {
+    let bestAt = 0;
+    let bestFan = Infinity;
+    for (let i = 0; i < remaining.length; i++) {
+      const fan = __orderFanout(facts, remaining[i], bound);
+      if (fan < bestFan) {
+        bestFan = fan;
+        bestAt = i;
+      }
+    }
+    const picked = remaining.splice(bestAt, 1)[0];
+    __orderBindTerm(picked.s, bound);
+    __orderBindTerm(picked.o, bound);
+    greedy.push(picked);
+  }
+
+  const greedyCost = __orderCost(greedy, facts, boundStart);
+  if (greedyCost * GOAL_ORDER_MIN_GAIN > writtenCost) return null;
+  return greedy;
+}
+
 // With opts.onSolution the caller takes each solution as it is found and gets back
 // the count, so an answer set is never held as an array. Callers that omit it get
 // the array and behave exactly as before.
@@ -10195,6 +10304,13 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   const initialGoals = Array.isArray(goals) ? goals.slice() : [];
   const substMut = subst ? __cloneSubst(subst) : {};
   const initialVisited = visited ? visited.slice() : [];
+
+  if (allowDeferredBuiltins) {
+    const reordered = __reorderBodyForCost(initialGoals, substMut, facts, backRules);
+    if (reordered && reordered.length === initialGoals.length) {
+      for (let i = 0; i < initialGoals.length; i++) initialGoals[i] = reordered[i];
+    }
+  }
 
   // Variables from the original goal list (needed by the caller to instantiate conclusions)
   const answerVars = new Set();

--- a/dist/browser/eyeling.browser.js
+++ b/dist/browser/eyeling.browser.js
@@ -7627,9 +7627,10 @@ function __setHiddenWritable(obj, name, value) {
 const FACT_INDEX_ARRAY_FIELDS = ['__varPred', '__varPredNonFastS', '__varPredNonFastO'];
 const FACT_INDEX_ARRAY_MAP_FIELDS = ['__byPred', '__byPNonFastS', '__byPNonFastO', '__varPredPS', '__varPredPO'];
 const FACT_INDEX_NESTED_ARRAY_MAP_FIELDS = ['__byPS', '__byPO'];
-const FACT_INDEX_MAP_FIELDS = FACT_INDEX_ARRAY_MAP_FIELDS.concat(FACT_INDEX_NESTED_ARRAY_MAP_FIELDS);
-const FACT_INDEX_REQUIRED_FIELDS = FACT_INDEX_ARRAY_FIELDS.concat(FACT_INDEX_MAP_FIELDS, ['__keySet', '__deepListS']);
-const FACT_INDEX_ALL_FIELDS = FACT_INDEX_REQUIRED_FIELDS.concat(['__keySetComplete']);
+const FACT_INDEX_PSO_FIELDS = ['__byPSO'];
+const FACT_INDEX_MAP_FIELDS = FACT_INDEX_ARRAY_MAP_FIELDS.concat(FACT_INDEX_NESTED_ARRAY_MAP_FIELDS, FACT_INDEX_PSO_FIELDS);
+const FACT_INDEX_REQUIRED_FIELDS = FACT_INDEX_ARRAY_FIELDS.concat(FACT_INDEX_MAP_FIELDS, ['__deepListS']);
+const FACT_INDEX_ALL_FIELDS = FACT_INDEX_REQUIRED_FIELDS;
 
 let version = 'dev';
 try {
@@ -8723,7 +8724,9 @@ function alphaEqGraphTriples(xs, ys, opts) {
 //       like a Prolog clause index keeps variable-headed clauses as fallback.
 //   - __varPred* indexes: facts whose predicate is a Var.  Only these non-IRI
 //       predicate facts can unify with a ground IRI predicate goal.
-//   - __keySet: Set<"S\tP\tO"> for Iri/Literal/Blank-only triples (fast dup check)
+//   - __byPSO:  Map<predicateId, Map<subjectKey, Map<objectKey, number|number[]>>>
+//       Exact position bucket. Lookup keys are complete for the equality
+//       triplesEqual accepts, so a miss is conclusive: no scan is needed.
 //
 // Backward rules:
 //   - __byHeadPred:   Map<headPredicateId, Rule[]>
@@ -8862,14 +8865,6 @@ function termLookupKey(t) {
   return null;
 }
 
-function tripleFastKey(tr) {
-  const ks = termFastKey(tr.s);
-  const kp = termFastKey(tr.p);
-  const ko = termFastKey(tr.o);
-  if (ks === null || kp === null || ko === null) return null;
-  return ks + '\t' + kp + '\t' + ko;
-}
-
 function resetFactIndexes(facts) {
   if (!facts) return;
   for (const name of FACT_INDEX_ALL_FIELDS) {
@@ -8882,15 +8877,9 @@ function ensureFactIndexes(facts) {
 
   for (const name of FACT_INDEX_MAP_FIELDS) __defineHiddenWritable(facts, name, new Map());
   for (const name of FACT_INDEX_ARRAY_FIELDS) __defineHiddenWritable(facts, name, []);
-  __defineHiddenWritable(facts, '__keySet', new Set());
   __defineHiddenWritable(facts, '__deepListS', new Map());
-  __defineHiddenWritable(facts, '__keySetComplete', false);
 
-  // Build lookup indexes eagerly, but do not populate the duplicate-detection
-  // string Set for every input fact.  The predicate/subject/object indexes are
-  // enough to verify duplicates when needed; avoiding 100k+ joined string keys
-  // saves substantial time and GC on data-heavy query workloads.
-  for (let i = 0; i < facts.length; i++) indexFact(facts, facts[i], i, false);
+  for (let i = 0; i < facts.length; i++) indexFact(facts, facts[i], i);
 }
 
 function cloneFactIndexesForSnapshot(src, dest) {
@@ -8899,6 +8888,20 @@ function cloneFactIndexesForSnapshot(src, dest) {
   function cloneArrayMap(map) {
     const out = new Map();
     for (const [k, arr] of map) out.set(k, arr.slice());
+    return out;
+  }
+
+  function clonePsoMap(map) {
+    const out = new Map();
+    for (const [pk, byS] of map) {
+      const outS = new Map();
+      for (const [sk, byO] of byS) {
+        const outO = new Map();
+        for (const [ok, v] of byO) outO.set(ok, typeof v === 'number' ? v : v.slice());
+        outS.set(sk, outO);
+      }
+      out.set(pk, outS);
+    }
     return out;
   }
 
@@ -8914,10 +8917,9 @@ function cloneFactIndexesForSnapshot(src, dest) {
 
   for (const name of FACT_INDEX_ARRAY_MAP_FIELDS) __defineHiddenWritable(dest, name, cloneArrayMap(src[name]));
   for (const name of FACT_INDEX_NESTED_ARRAY_MAP_FIELDS) __defineHiddenWritable(dest, name, cloneNestedArrayMap(src[name]));
+  for (const name of FACT_INDEX_PSO_FIELDS) __defineHiddenWritable(dest, name, clonePsoMap(src[name]));
   for (const name of FACT_INDEX_ARRAY_FIELDS) __defineHiddenWritable(dest, name, src[name].slice());
-  __defineHiddenWritable(dest, '__keySet', new Set(src.__keySet));
   __defineHiddenWritable(dest, '__deepListS', new Map());
-  __defineHiddenWritable(dest, '__keySetComplete', !!src.__keySetComplete);
 }
 
 function pushMapArray(map, key, value) {
@@ -8938,16 +8940,14 @@ function getOrCreateMap(map, key) {
   return inner;
 }
 
-function indexFact(facts, tr, idx, addKeySet = true) {
+function indexFact(facts, tr, idx) {
   facts.__deepListS.clear();
   const sk = termLookupKey(tr.s);
   const ok = termLookupKey(tr.o);
-  let pkForKey = null;
 
   if (tr.p instanceof Iri) {
     // Use predicate term id as the primary key to avoid hashing long IRI strings.
     const pk = tr.p.__tid;
-    pkForKey = pk;
 
     pushMapArray(facts.__byPred, pk, idx);
 
@@ -8961,6 +8961,14 @@ function indexFact(facts, tr, idx, addKeySet = true) {
       pushMapArray(getOrCreateMap(facts.__byPO, pk), ok, idx);
     } else {
       pushMapArray(facts.__byPNonFastO, pk, idx);
+    }
+
+    if (sk !== null && ok !== null) {
+      const byO = getOrCreateMap(getOrCreateMap(facts.__byPSO, pk), sk);
+      const prev = byO.get(ok);
+      if (prev === undefined) byO.set(ok, idx);
+      else if (typeof prev === 'number') byO.set(ok, [prev, idx]);
+      else prev.push(idx);
     }
   } else if (tr.p instanceof Var) {
     facts.__varPred.push(idx);
@@ -8978,10 +8986,6 @@ function indexFact(facts, tr, idx, addKeySet = true) {
     }
   }
 
-  if (addKeySet && sk !== null && ok !== null) {
-    if (pkForKey === null) pkForKey = termFastKey(tr.p);
-    if (pkForKey !== null) facts.__keySet.add(sk + '\t' + pkForKey + '\t' + ok);
-  }
 }
 
 function mergeIndexBuckets(primary, fallback) {
@@ -9141,15 +9145,25 @@ function candidateFacts(facts, goal) {
 function hasFactIndexed(facts, tr) {
   ensureFactIndexes(facts);
 
-  const key = tripleFastKey(tr);
-  if (key !== null) {
-    if (facts.__keySet.has(key)) return true;
-    if (facts.__keySetComplete) return false;
-  }
 
   if (tr.p instanceof Iri) {
     const pk = tr.p.__tid;
     const sk = termLookupKey(tr.s);
+
+    // A fact equal to `tr` has equal lookup keys, so when both keys exist the
+    // exact bucket decides membership outright: absent means absent.
+    if (sk !== null) {
+      const okExact = termLookupKey(tr.o);
+      if (okExact !== null) {
+        const byS = facts.__byPSO.get(pk);
+        const byO = byS === undefined ? undefined : byS.get(sk);
+        const hit = byO === undefined ? undefined : byO.get(okExact);
+        if (hit === undefined) return false;
+        if (typeof hit === 'number') return triplesEqual(facts[hit], tr);
+        return hit.some((i) => triplesEqual(facts[i], tr));
+      }
+    }
+
     let best = null;
 
     if (sk !== null) {
@@ -9183,7 +9197,7 @@ function pushFactIndexed(facts, tr) {
   ensureFactIndexes(facts);
   const idx = facts.length;
   facts.push(tr);
-  indexFact(facts, tr, idx, true);
+  indexFact(facts, tr, idx);
 }
 
 function makeDerivedRecord(fact, rule, premises, subst, captureExplanations) {

--- a/eyeling.js
+++ b/eyeling.js
@@ -10145,6 +10145,115 @@ function __builtinIsSatisfiableWhenFullyUnbound(pIriVal) {
   return MATH_BUILTINS_SATISFIABLE_WHEN_FULLY_UNBOUND.has(pIriVal);
 }
 
+
+// Cost-gated body ordering for forward rules.
+//
+// A conjunction is evaluated left to right, so a body that opens with unselective
+// patterns enumerates their product before any shared variable can prune it. Only
+// fact-lookup goals are considered here: a goal that a backward rule could answer
+// keeps its written position, because rule selection order is load-bearing for
+// termination. The written order is kept unless the estimate says it is
+// catastrophically worse, so ordinary programs — and their output order — do not move.
+const GOAL_ORDER_MIN_GOALS = 3;
+const GOAL_ORDER_MIN_COST = 1e6;
+const GOAL_ORDER_MIN_GAIN = 100;
+
+function __orderCandidateTerm(t) {
+  return t instanceof Iri || t instanceof Literal || t instanceof Blank || t instanceof Var;
+}
+
+function __orderCandidateGoal(tr, backRules) {
+  if (!tr || !(tr.p instanceof Iri)) return false;
+  if (isBuiltinPred(tr.p)) return false;
+  if (backRules.__wildHeadPred && backRules.__wildHeadPred.length) return false;
+  if (backRules.__byHeadPred && backRules.__byHeadPred.has(tr.p.__tid)) return false;
+  return __orderCandidateTerm(tr.s) && __orderCandidateTerm(tr.o);
+}
+
+function __orderTermIsBound(term, bound) {
+  if (term instanceof Var) return bound.has(term.name);
+  if (term instanceof Blank) return bound.has(term.label);
+  return true;
+}
+
+function __orderBindTerm(term, bound) {
+  if (term instanceof Var) bound.add(term.name);
+  else if (term instanceof Blank) bound.add(term.label);
+}
+
+// Expected matches for one binding of what is already bound.
+function __orderFanout(facts, tr, bound) {
+  const pk = tr.p.__tid;
+  const all = facts.__byPred.get(pk);
+  const extent = all ? all.length : 0;
+  if (extent === 0) return 0;
+
+  const sBound = __orderTermIsBound(tr.s, bound);
+  const oBound = __orderTermIsBound(tr.o, bound);
+  let est = extent;
+  if (sBound) {
+    const byS = facts.__byPS.get(pk);
+    if (byS && byS.size) est = Math.min(est, extent / byS.size);
+  }
+  if (oBound) {
+    const byO = facts.__byPO.get(pk);
+    if (byO && byO.size) est = Math.min(est, extent / byO.size);
+  }
+  if (sBound && oBound) est = Math.min(est, 1);
+  return est;
+}
+
+function __orderCost(order, facts, boundStart) {
+  const bound = new Set(boundStart);
+  let card = 1;
+  let cost = 0;
+  for (let i = 0; i < order.length; i++) {
+    const parent = card;
+    card *= __orderFanout(facts, order[i], bound);
+    cost += Math.max(parent, card);
+    __orderBindTerm(order[i].s, bound);
+    __orderBindTerm(order[i].o, bound);
+    if (card === 0) break;
+  }
+  return cost;
+}
+
+function __reorderBodyForCost(goals, subst, facts, backRules) {
+  if (goals.length < GOAL_ORDER_MIN_GOALS) return null;
+  for (let i = 0; i < goals.length; i++) {
+    if (!__orderCandidateGoal(goals[i], backRules)) return null;
+  }
+
+  const boundStart = new Set();
+  if (subst) for (const k in subst) if (hasOwn.call(subst, k)) boundStart.add(k);
+
+  const writtenCost = __orderCost(goals, facts, boundStart);
+  if (!(writtenCost > GOAL_ORDER_MIN_COST)) return null;
+
+  const bound = new Set(boundStart);
+  const remaining = goals.slice();
+  const greedy = [];
+  while (remaining.length) {
+    let bestAt = 0;
+    let bestFan = Infinity;
+    for (let i = 0; i < remaining.length; i++) {
+      const fan = __orderFanout(facts, remaining[i], bound);
+      if (fan < bestFan) {
+        bestFan = fan;
+        bestAt = i;
+      }
+    }
+    const picked = remaining.splice(bestAt, 1)[0];
+    __orderBindTerm(picked.s, bound);
+    __orderBindTerm(picked.o, bound);
+    greedy.push(picked);
+  }
+
+  const greedyCost = __orderCost(greedy, facts, boundStart);
+  if (greedyCost * GOAL_ORDER_MIN_GAIN > writtenCost) return null;
+  return greedy;
+}
+
 // With opts.onSolution the caller takes each solution as it is found and gets back
 // the count, so an answer set is never held as an array. Callers that omit it get
 // the array and behave exactly as before.
@@ -10195,6 +10304,13 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   const initialGoals = Array.isArray(goals) ? goals.slice() : [];
   const substMut = subst ? __cloneSubst(subst) : {};
   const initialVisited = visited ? visited.slice() : [];
+
+  if (allowDeferredBuiltins) {
+    const reordered = __reorderBodyForCost(initialGoals, substMut, facts, backRules);
+    if (reordered && reordered.length === initialGoals.length) {
+      for (let i = 0; i < initialGoals.length; i++) initialGoals[i] = reordered[i];
+    }
+  }
 
   // Variables from the original goal list (needed by the caller to instantiate conclusions)
   const answerVars = new Set();

--- a/eyeling.js
+++ b/eyeling.js
@@ -7627,9 +7627,10 @@ function __setHiddenWritable(obj, name, value) {
 const FACT_INDEX_ARRAY_FIELDS = ['__varPred', '__varPredNonFastS', '__varPredNonFastO'];
 const FACT_INDEX_ARRAY_MAP_FIELDS = ['__byPred', '__byPNonFastS', '__byPNonFastO', '__varPredPS', '__varPredPO'];
 const FACT_INDEX_NESTED_ARRAY_MAP_FIELDS = ['__byPS', '__byPO'];
-const FACT_INDEX_MAP_FIELDS = FACT_INDEX_ARRAY_MAP_FIELDS.concat(FACT_INDEX_NESTED_ARRAY_MAP_FIELDS);
-const FACT_INDEX_REQUIRED_FIELDS = FACT_INDEX_ARRAY_FIELDS.concat(FACT_INDEX_MAP_FIELDS, ['__keySet', '__deepListS']);
-const FACT_INDEX_ALL_FIELDS = FACT_INDEX_REQUIRED_FIELDS.concat(['__keySetComplete']);
+const FACT_INDEX_PSO_FIELDS = ['__byPSO'];
+const FACT_INDEX_MAP_FIELDS = FACT_INDEX_ARRAY_MAP_FIELDS.concat(FACT_INDEX_NESTED_ARRAY_MAP_FIELDS, FACT_INDEX_PSO_FIELDS);
+const FACT_INDEX_REQUIRED_FIELDS = FACT_INDEX_ARRAY_FIELDS.concat(FACT_INDEX_MAP_FIELDS, ['__deepListS']);
+const FACT_INDEX_ALL_FIELDS = FACT_INDEX_REQUIRED_FIELDS;
 
 let version = 'dev';
 try {
@@ -8723,7 +8724,9 @@ function alphaEqGraphTriples(xs, ys, opts) {
 //       like a Prolog clause index keeps variable-headed clauses as fallback.
 //   - __varPred* indexes: facts whose predicate is a Var.  Only these non-IRI
 //       predicate facts can unify with a ground IRI predicate goal.
-//   - __keySet: Set<"S\tP\tO"> for Iri/Literal/Blank-only triples (fast dup check)
+//   - __byPSO:  Map<predicateId, Map<subjectKey, Map<objectKey, number|number[]>>>
+//       Exact position bucket. Lookup keys are complete for the equality
+//       triplesEqual accepts, so a miss is conclusive: no scan is needed.
 //
 // Backward rules:
 //   - __byHeadPred:   Map<headPredicateId, Rule[]>
@@ -8862,14 +8865,6 @@ function termLookupKey(t) {
   return null;
 }
 
-function tripleFastKey(tr) {
-  const ks = termFastKey(tr.s);
-  const kp = termFastKey(tr.p);
-  const ko = termFastKey(tr.o);
-  if (ks === null || kp === null || ko === null) return null;
-  return ks + '\t' + kp + '\t' + ko;
-}
-
 function resetFactIndexes(facts) {
   if (!facts) return;
   for (const name of FACT_INDEX_ALL_FIELDS) {
@@ -8882,15 +8877,9 @@ function ensureFactIndexes(facts) {
 
   for (const name of FACT_INDEX_MAP_FIELDS) __defineHiddenWritable(facts, name, new Map());
   for (const name of FACT_INDEX_ARRAY_FIELDS) __defineHiddenWritable(facts, name, []);
-  __defineHiddenWritable(facts, '__keySet', new Set());
   __defineHiddenWritable(facts, '__deepListS', new Map());
-  __defineHiddenWritable(facts, '__keySetComplete', false);
 
-  // Build lookup indexes eagerly, but do not populate the duplicate-detection
-  // string Set for every input fact.  The predicate/subject/object indexes are
-  // enough to verify duplicates when needed; avoiding 100k+ joined string keys
-  // saves substantial time and GC on data-heavy query workloads.
-  for (let i = 0; i < facts.length; i++) indexFact(facts, facts[i], i, false);
+  for (let i = 0; i < facts.length; i++) indexFact(facts, facts[i], i);
 }
 
 function cloneFactIndexesForSnapshot(src, dest) {
@@ -8899,6 +8888,20 @@ function cloneFactIndexesForSnapshot(src, dest) {
   function cloneArrayMap(map) {
     const out = new Map();
     for (const [k, arr] of map) out.set(k, arr.slice());
+    return out;
+  }
+
+  function clonePsoMap(map) {
+    const out = new Map();
+    for (const [pk, byS] of map) {
+      const outS = new Map();
+      for (const [sk, byO] of byS) {
+        const outO = new Map();
+        for (const [ok, v] of byO) outO.set(ok, typeof v === 'number' ? v : v.slice());
+        outS.set(sk, outO);
+      }
+      out.set(pk, outS);
+    }
     return out;
   }
 
@@ -8914,10 +8917,9 @@ function cloneFactIndexesForSnapshot(src, dest) {
 
   for (const name of FACT_INDEX_ARRAY_MAP_FIELDS) __defineHiddenWritable(dest, name, cloneArrayMap(src[name]));
   for (const name of FACT_INDEX_NESTED_ARRAY_MAP_FIELDS) __defineHiddenWritable(dest, name, cloneNestedArrayMap(src[name]));
+  for (const name of FACT_INDEX_PSO_FIELDS) __defineHiddenWritable(dest, name, clonePsoMap(src[name]));
   for (const name of FACT_INDEX_ARRAY_FIELDS) __defineHiddenWritable(dest, name, src[name].slice());
-  __defineHiddenWritable(dest, '__keySet', new Set(src.__keySet));
   __defineHiddenWritable(dest, '__deepListS', new Map());
-  __defineHiddenWritable(dest, '__keySetComplete', !!src.__keySetComplete);
 }
 
 function pushMapArray(map, key, value) {
@@ -8938,16 +8940,14 @@ function getOrCreateMap(map, key) {
   return inner;
 }
 
-function indexFact(facts, tr, idx, addKeySet = true) {
+function indexFact(facts, tr, idx) {
   facts.__deepListS.clear();
   const sk = termLookupKey(tr.s);
   const ok = termLookupKey(tr.o);
-  let pkForKey = null;
 
   if (tr.p instanceof Iri) {
     // Use predicate term id as the primary key to avoid hashing long IRI strings.
     const pk = tr.p.__tid;
-    pkForKey = pk;
 
     pushMapArray(facts.__byPred, pk, idx);
 
@@ -8961,6 +8961,14 @@ function indexFact(facts, tr, idx, addKeySet = true) {
       pushMapArray(getOrCreateMap(facts.__byPO, pk), ok, idx);
     } else {
       pushMapArray(facts.__byPNonFastO, pk, idx);
+    }
+
+    if (sk !== null && ok !== null) {
+      const byO = getOrCreateMap(getOrCreateMap(facts.__byPSO, pk), sk);
+      const prev = byO.get(ok);
+      if (prev === undefined) byO.set(ok, idx);
+      else if (typeof prev === 'number') byO.set(ok, [prev, idx]);
+      else prev.push(idx);
     }
   } else if (tr.p instanceof Var) {
     facts.__varPred.push(idx);
@@ -8978,10 +8986,6 @@ function indexFact(facts, tr, idx, addKeySet = true) {
     }
   }
 
-  if (addKeySet && sk !== null && ok !== null) {
-    if (pkForKey === null) pkForKey = termFastKey(tr.p);
-    if (pkForKey !== null) facts.__keySet.add(sk + '\t' + pkForKey + '\t' + ok);
-  }
 }
 
 function mergeIndexBuckets(primary, fallback) {
@@ -9141,15 +9145,25 @@ function candidateFacts(facts, goal) {
 function hasFactIndexed(facts, tr) {
   ensureFactIndexes(facts);
 
-  const key = tripleFastKey(tr);
-  if (key !== null) {
-    if (facts.__keySet.has(key)) return true;
-    if (facts.__keySetComplete) return false;
-  }
 
   if (tr.p instanceof Iri) {
     const pk = tr.p.__tid;
     const sk = termLookupKey(tr.s);
+
+    // A fact equal to `tr` has equal lookup keys, so when both keys exist the
+    // exact bucket decides membership outright: absent means absent.
+    if (sk !== null) {
+      const okExact = termLookupKey(tr.o);
+      if (okExact !== null) {
+        const byS = facts.__byPSO.get(pk);
+        const byO = byS === undefined ? undefined : byS.get(sk);
+        const hit = byO === undefined ? undefined : byO.get(okExact);
+        if (hit === undefined) return false;
+        if (typeof hit === 'number') return triplesEqual(facts[hit], tr);
+        return hit.some((i) => triplesEqual(facts[i], tr));
+      }
+    }
+
     let best = null;
 
     if (sk !== null) {
@@ -9183,7 +9197,7 @@ function pushFactIndexed(facts, tr) {
   ensureFactIndexes(facts);
   const idx = facts.length;
   facts.push(tr);
-  indexFact(facts, tr, idx, true);
+  indexFact(facts, tr, idx);
 }
 
 function makeDerivedRecord(fact, rule, premises, subst, captureExplanations) {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -144,9 +144,10 @@ function __setHiddenWritable(obj, name, value) {
 const FACT_INDEX_ARRAY_FIELDS = ['__varPred', '__varPredNonFastS', '__varPredNonFastO'];
 const FACT_INDEX_ARRAY_MAP_FIELDS = ['__byPred', '__byPNonFastS', '__byPNonFastO', '__varPredPS', '__varPredPO'];
 const FACT_INDEX_NESTED_ARRAY_MAP_FIELDS = ['__byPS', '__byPO'];
-const FACT_INDEX_MAP_FIELDS = FACT_INDEX_ARRAY_MAP_FIELDS.concat(FACT_INDEX_NESTED_ARRAY_MAP_FIELDS);
-const FACT_INDEX_REQUIRED_FIELDS = FACT_INDEX_ARRAY_FIELDS.concat(FACT_INDEX_MAP_FIELDS, ['__keySet', '__deepListS']);
-const FACT_INDEX_ALL_FIELDS = FACT_INDEX_REQUIRED_FIELDS.concat(['__keySetComplete']);
+const FACT_INDEX_PSO_FIELDS = ['__byPSO'];
+const FACT_INDEX_MAP_FIELDS = FACT_INDEX_ARRAY_MAP_FIELDS.concat(FACT_INDEX_NESTED_ARRAY_MAP_FIELDS, FACT_INDEX_PSO_FIELDS);
+const FACT_INDEX_REQUIRED_FIELDS = FACT_INDEX_ARRAY_FIELDS.concat(FACT_INDEX_MAP_FIELDS, ['__deepListS']);
+const FACT_INDEX_ALL_FIELDS = FACT_INDEX_REQUIRED_FIELDS;
 
 let version = 'dev';
 try {
@@ -1240,7 +1241,9 @@ function alphaEqGraphTriples(xs, ys, opts) {
 //       like a Prolog clause index keeps variable-headed clauses as fallback.
 //   - __varPred* indexes: facts whose predicate is a Var.  Only these non-IRI
 //       predicate facts can unify with a ground IRI predicate goal.
-//   - __keySet: Set<"S\tP\tO"> for Iri/Literal/Blank-only triples (fast dup check)
+//   - __byPSO:  Map<predicateId, Map<subjectKey, Map<objectKey, number|number[]>>>
+//       Exact position bucket. Lookup keys are complete for the equality
+//       triplesEqual accepts, so a miss is conclusive: no scan is needed.
 //
 // Backward rules:
 //   - __byHeadPred:   Map<headPredicateId, Rule[]>
@@ -1379,14 +1382,6 @@ function termLookupKey(t) {
   return null;
 }
 
-function tripleFastKey(tr) {
-  const ks = termFastKey(tr.s);
-  const kp = termFastKey(tr.p);
-  const ko = termFastKey(tr.o);
-  if (ks === null || kp === null || ko === null) return null;
-  return ks + '\t' + kp + '\t' + ko;
-}
-
 function resetFactIndexes(facts) {
   if (!facts) return;
   for (const name of FACT_INDEX_ALL_FIELDS) {
@@ -1399,15 +1394,9 @@ function ensureFactIndexes(facts) {
 
   for (const name of FACT_INDEX_MAP_FIELDS) __defineHiddenWritable(facts, name, new Map());
   for (const name of FACT_INDEX_ARRAY_FIELDS) __defineHiddenWritable(facts, name, []);
-  __defineHiddenWritable(facts, '__keySet', new Set());
   __defineHiddenWritable(facts, '__deepListS', new Map());
-  __defineHiddenWritable(facts, '__keySetComplete', false);
 
-  // Build lookup indexes eagerly, but do not populate the duplicate-detection
-  // string Set for every input fact.  The predicate/subject/object indexes are
-  // enough to verify duplicates when needed; avoiding 100k+ joined string keys
-  // saves substantial time and GC on data-heavy query workloads.
-  for (let i = 0; i < facts.length; i++) indexFact(facts, facts[i], i, false);
+  for (let i = 0; i < facts.length; i++) indexFact(facts, facts[i], i);
 }
 
 function cloneFactIndexesForSnapshot(src, dest) {
@@ -1416,6 +1405,20 @@ function cloneFactIndexesForSnapshot(src, dest) {
   function cloneArrayMap(map) {
     const out = new Map();
     for (const [k, arr] of map) out.set(k, arr.slice());
+    return out;
+  }
+
+  function clonePsoMap(map) {
+    const out = new Map();
+    for (const [pk, byS] of map) {
+      const outS = new Map();
+      for (const [sk, byO] of byS) {
+        const outO = new Map();
+        for (const [ok, v] of byO) outO.set(ok, typeof v === 'number' ? v : v.slice());
+        outS.set(sk, outO);
+      }
+      out.set(pk, outS);
+    }
     return out;
   }
 
@@ -1431,10 +1434,9 @@ function cloneFactIndexesForSnapshot(src, dest) {
 
   for (const name of FACT_INDEX_ARRAY_MAP_FIELDS) __defineHiddenWritable(dest, name, cloneArrayMap(src[name]));
   for (const name of FACT_INDEX_NESTED_ARRAY_MAP_FIELDS) __defineHiddenWritable(dest, name, cloneNestedArrayMap(src[name]));
+  for (const name of FACT_INDEX_PSO_FIELDS) __defineHiddenWritable(dest, name, clonePsoMap(src[name]));
   for (const name of FACT_INDEX_ARRAY_FIELDS) __defineHiddenWritable(dest, name, src[name].slice());
-  __defineHiddenWritable(dest, '__keySet', new Set(src.__keySet));
   __defineHiddenWritable(dest, '__deepListS', new Map());
-  __defineHiddenWritable(dest, '__keySetComplete', !!src.__keySetComplete);
 }
 
 function pushMapArray(map, key, value) {
@@ -1455,16 +1457,14 @@ function getOrCreateMap(map, key) {
   return inner;
 }
 
-function indexFact(facts, tr, idx, addKeySet = true) {
+function indexFact(facts, tr, idx) {
   facts.__deepListS.clear();
   const sk = termLookupKey(tr.s);
   const ok = termLookupKey(tr.o);
-  let pkForKey = null;
 
   if (tr.p instanceof Iri) {
     // Use predicate term id as the primary key to avoid hashing long IRI strings.
     const pk = tr.p.__tid;
-    pkForKey = pk;
 
     pushMapArray(facts.__byPred, pk, idx);
 
@@ -1478,6 +1478,14 @@ function indexFact(facts, tr, idx, addKeySet = true) {
       pushMapArray(getOrCreateMap(facts.__byPO, pk), ok, idx);
     } else {
       pushMapArray(facts.__byPNonFastO, pk, idx);
+    }
+
+    if (sk !== null && ok !== null) {
+      const byO = getOrCreateMap(getOrCreateMap(facts.__byPSO, pk), sk);
+      const prev = byO.get(ok);
+      if (prev === undefined) byO.set(ok, idx);
+      else if (typeof prev === 'number') byO.set(ok, [prev, idx]);
+      else prev.push(idx);
     }
   } else if (tr.p instanceof Var) {
     facts.__varPred.push(idx);
@@ -1495,10 +1503,6 @@ function indexFact(facts, tr, idx, addKeySet = true) {
     }
   }
 
-  if (addKeySet && sk !== null && ok !== null) {
-    if (pkForKey === null) pkForKey = termFastKey(tr.p);
-    if (pkForKey !== null) facts.__keySet.add(sk + '\t' + pkForKey + '\t' + ok);
-  }
 }
 
 function mergeIndexBuckets(primary, fallback) {
@@ -1658,15 +1662,25 @@ function candidateFacts(facts, goal) {
 function hasFactIndexed(facts, tr) {
   ensureFactIndexes(facts);
 
-  const key = tripleFastKey(tr);
-  if (key !== null) {
-    if (facts.__keySet.has(key)) return true;
-    if (facts.__keySetComplete) return false;
-  }
 
   if (tr.p instanceof Iri) {
     const pk = tr.p.__tid;
     const sk = termLookupKey(tr.s);
+
+    // A fact equal to `tr` has equal lookup keys, so when both keys exist the
+    // exact bucket decides membership outright: absent means absent.
+    if (sk !== null) {
+      const okExact = termLookupKey(tr.o);
+      if (okExact !== null) {
+        const byS = facts.__byPSO.get(pk);
+        const byO = byS === undefined ? undefined : byS.get(sk);
+        const hit = byO === undefined ? undefined : byO.get(okExact);
+        if (hit === undefined) return false;
+        if (typeof hit === 'number') return triplesEqual(facts[hit], tr);
+        return hit.some((i) => triplesEqual(facts[i], tr));
+      }
+    }
+
     let best = null;
 
     if (sk !== null) {
@@ -1700,7 +1714,7 @@ function pushFactIndexed(facts, tr) {
   ensureFactIndexes(facts);
   const idx = facts.length;
   facts.push(tr);
-  indexFact(facts, tr, idx, true);
+  indexFact(facts, tr, idx);
 }
 
 function makeDerivedRecord(fact, rule, premises, subst, captureExplanations) {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -2662,6 +2662,115 @@ function __builtinIsSatisfiableWhenFullyUnbound(pIriVal) {
   return MATH_BUILTINS_SATISFIABLE_WHEN_FULLY_UNBOUND.has(pIriVal);
 }
 
+
+// Cost-gated body ordering for forward rules.
+//
+// A conjunction is evaluated left to right, so a body that opens with unselective
+// patterns enumerates their product before any shared variable can prune it. Only
+// fact-lookup goals are considered here: a goal that a backward rule could answer
+// keeps its written position, because rule selection order is load-bearing for
+// termination. The written order is kept unless the estimate says it is
+// catastrophically worse, so ordinary programs — and their output order — do not move.
+const GOAL_ORDER_MIN_GOALS = 3;
+const GOAL_ORDER_MIN_COST = 1e6;
+const GOAL_ORDER_MIN_GAIN = 100;
+
+function __orderCandidateTerm(t) {
+  return t instanceof Iri || t instanceof Literal || t instanceof Blank || t instanceof Var;
+}
+
+function __orderCandidateGoal(tr, backRules) {
+  if (!tr || !(tr.p instanceof Iri)) return false;
+  if (isBuiltinPred(tr.p)) return false;
+  if (backRules.__wildHeadPred && backRules.__wildHeadPred.length) return false;
+  if (backRules.__byHeadPred && backRules.__byHeadPred.has(tr.p.__tid)) return false;
+  return __orderCandidateTerm(tr.s) && __orderCandidateTerm(tr.o);
+}
+
+function __orderTermIsBound(term, bound) {
+  if (term instanceof Var) return bound.has(term.name);
+  if (term instanceof Blank) return bound.has(term.label);
+  return true;
+}
+
+function __orderBindTerm(term, bound) {
+  if (term instanceof Var) bound.add(term.name);
+  else if (term instanceof Blank) bound.add(term.label);
+}
+
+// Expected matches for one binding of what is already bound.
+function __orderFanout(facts, tr, bound) {
+  const pk = tr.p.__tid;
+  const all = facts.__byPred.get(pk);
+  const extent = all ? all.length : 0;
+  if (extent === 0) return 0;
+
+  const sBound = __orderTermIsBound(tr.s, bound);
+  const oBound = __orderTermIsBound(tr.o, bound);
+  let est = extent;
+  if (sBound) {
+    const byS = facts.__byPS.get(pk);
+    if (byS && byS.size) est = Math.min(est, extent / byS.size);
+  }
+  if (oBound) {
+    const byO = facts.__byPO.get(pk);
+    if (byO && byO.size) est = Math.min(est, extent / byO.size);
+  }
+  if (sBound && oBound) est = Math.min(est, 1);
+  return est;
+}
+
+function __orderCost(order, facts, boundStart) {
+  const bound = new Set(boundStart);
+  let card = 1;
+  let cost = 0;
+  for (let i = 0; i < order.length; i++) {
+    const parent = card;
+    card *= __orderFanout(facts, order[i], bound);
+    cost += Math.max(parent, card);
+    __orderBindTerm(order[i].s, bound);
+    __orderBindTerm(order[i].o, bound);
+    if (card === 0) break;
+  }
+  return cost;
+}
+
+function __reorderBodyForCost(goals, subst, facts, backRules) {
+  if (goals.length < GOAL_ORDER_MIN_GOALS) return null;
+  for (let i = 0; i < goals.length; i++) {
+    if (!__orderCandidateGoal(goals[i], backRules)) return null;
+  }
+
+  const boundStart = new Set();
+  if (subst) for (const k in subst) if (hasOwn.call(subst, k)) boundStart.add(k);
+
+  const writtenCost = __orderCost(goals, facts, boundStart);
+  if (!(writtenCost > GOAL_ORDER_MIN_COST)) return null;
+
+  const bound = new Set(boundStart);
+  const remaining = goals.slice();
+  const greedy = [];
+  while (remaining.length) {
+    let bestAt = 0;
+    let bestFan = Infinity;
+    for (let i = 0; i < remaining.length; i++) {
+      const fan = __orderFanout(facts, remaining[i], bound);
+      if (fan < bestFan) {
+        bestFan = fan;
+        bestAt = i;
+      }
+    }
+    const picked = remaining.splice(bestAt, 1)[0];
+    __orderBindTerm(picked.s, bound);
+    __orderBindTerm(picked.o, bound);
+    greedy.push(picked);
+  }
+
+  const greedyCost = __orderCost(greedy, facts, boundStart);
+  if (greedyCost * GOAL_ORDER_MIN_GAIN > writtenCost) return null;
+  return greedy;
+}
+
 // With opts.onSolution the caller takes each solution as it is found and gets back
 // the count, so an answer set is never held as an array. Callers that omit it get
 // the array and behave exactly as before.
@@ -2712,6 +2821,13 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   const initialGoals = Array.isArray(goals) ? goals.slice() : [];
   const substMut = subst ? __cloneSubst(subst) : {};
   const initialVisited = visited ? visited.slice() : [];
+
+  if (allowDeferredBuiltins) {
+    const reordered = __reorderBodyForCost(initialGoals, substMut, facts, backRules);
+    if (reordered && reordered.length === initialGoals.length) {
+      for (let i = 0; i < initialGoals.length; i++) initialGoals[i] = reordered[i];
+    }
+  }
 
   // Variables from the original goal list (needed by the caller to instantiate conclusions)
   const answerVars = new Set();

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -259,6 +259,32 @@ ${U('c')} ${U('friend')} ${U('d')}.
 
 const cases = [
   {
+    name: '00z duplicate detection is value equality, verified per fact',
+    opt: { proofComments: false },
+    input: `
+  @prefix : <http://example.org/> .
+  @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+  :a :b "1.0"^^xsd:decimal .
+  :c :d 1 .
+  :e :f true .
+  :go :go :go .
+
+  { :go :go :go } => { :a :b "1.00"^^xsd:decimal } .
+  { :go :go :go } => { :c :d "01"^^xsd:integer } .
+  { :go :go :go } => { :e :f "1"^^xsd:boolean } .
+  `,
+    check(out) {
+      const s = String(out);
+      // Value-equal numerics are the same fact, so neither is re-derived.
+      assert.ok(!s.includes('1.00'), 'decimal duplicate was re-derived');
+      assert.ok(!s.includes('"01"'), 'integer duplicate was re-derived');
+      // A boolean shares an index key with `true` without being equal to it,
+      // so the fact must survive: an index hit alone may not decide membership.
+      assert.match(s, /:e\s+:f\s+true\s*\./);
+    },
+  },
+  {
     name: '00 parsing untyped literal ^^',
     opt: { proofComments: false },
     input: `

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -285,6 +285,55 @@ const cases = [
     },
   },
   {
+    name: '00y a body whose written order is catastrophic still yields exactly its answers',
+    opt: { proofComments: false },
+    input: (() => {
+      const lines = [
+        '@prefix : <http://example.org/> .',
+        '{ ?X a :T1 . ?Y a :T2 . ?Z a :T3 . ?X :p ?Y . ?Y :q ?Z } => { ?X :found ?Z } .',
+      ];
+      for (let i = 0; i < 150; i++) {
+        lines.push(`:x${i} a :T1 .`, `:y${i} a :T2 .`, `:z${i} a :T3 .`);
+      }
+      // The two answers.
+      lines.push(':x7 :p :y3 .', ':y3 :q :z9 .', ':x8 :p :y4 .', ':y4 :q :z2 .');
+      // One decoy per type atom: a complete :p/:q chain whose endpoint lacks the
+      // type, so dropping any one of the three atoms shows up as an extra answer.
+      lines.push(':xBad :p :y5 .', ':y5 :q :z5 .');
+      lines.push(':x6 :p :yBad .', ':yBad :q :z6 .');
+      lines.push(':x1 :p :y1 .', ':y1 :q :zBad .');
+      return lines.join('\n');
+    })(),
+    check(out) {
+      const s = String(out);
+      const found = (s.match(/:found/g) || []).length;
+      assert.equal(found, 2, `expected exactly 2 :found facts, got ${found} in:\n${s}`);
+      assert.match(s, /:x7\s+:found\s+:z9\s*\./);
+      assert.match(s, /:x8\s+:found\s+:z2\s*\./);
+    },
+  },
+  {
+    name: '00x a cheap body keeps its written evaluation order',
+    opt: { proofComments: false },
+    input: (() => {
+      const lines = ['@prefix : <http://example.org/> .'];
+      // :a is written first and is the least selective atom, so a cost-blind
+      // reordering would start from :b instead and find :w2 before :w1.
+      for (let i = 0; i < 100; i++) lines.push(`:pad${i} :a :nowhere .`);
+      lines.push(':w1 :a :p1 .', ':w2 :a :p2 .');
+      lines.push(':p2 :b :q2 .', ':p1 :b :q1 .');
+      lines.push(':q1 :c :out1 .', ':q2 :c :out2 .');
+      lines.push('{ ?W :a ?X . ?X :b ?Y . ?Y :c ?Z } => { ?W :found ?Z } .');
+      return lines.join('\n');
+    })(),
+    check(out) {
+      const order = String(out).split('\n').filter((l) => l.includes(':found'));
+      assert.equal(order.length, 2, `expected 2 derivations, got:\n${out}`);
+      assert.match(order[0], /:w1\s+:found\s+:out1\s*\./);
+      assert.match(order[1], /:w2\s+:found\s+:out2\s*\./);
+    },
+  },
+  {
     name: '00 parsing untyped literal ^^',
     opt: { proofComments: false },
     input: `


### PR DESCRIPTION
Two independent performance fixes to forward chaining, both output-preserving.
  
 - First, fact membership: there was no exact (p,s,o) bucket, so every genuinely
   new fact was checked by scanning everything that shared one position: 318M
    comparisons for 1.2M always-negative answers on OpenRuleBench join1, 53% of the
    profile. Indexing the position turns each of those into a single lookup, and
    makes the "S\tP\tO" string set redundant: 67.8s/866MB -> 30.6s/823MB. The cost
    is ~1-2% on load-dominated runs, to build the extra index.

 - Second, body order: a conjunction is evaluated left to right, so a body opening
    with an unselective pattern enumerates its product before anything can prune.
    The fact indexes already carry enough to estimate both orders, so a body is
    reordered only when the written order is at least 100x worse by that estimate.
    On LUBM(1) that takes three queries from 167s, 46s and >300s (timeout) to about
    3s each, all set-exact against the published answers — while firing on none of
    the 225 examples, so ordinary programs and the order they emit solutions in do
    not move.