### PR TITLE
Load a large document without overflowing the stack

### DIFF
--- a/dist/browser/eyeling.browser.js
+++ b/dist/browser/eyeling.browser.js
@@ -15658,6 +15658,14 @@ function mergePrefixEnvs(target, source) {
   return target;
 }
 
+// push(...array) gives every element its own stack argument slot, so a document
+// with more than ~128k triples overflows V8's argument limit. Append in a loop.
+function appendAll(target, source) {
+  if (!source) return target;
+  for (let i = 0; i < source.length; i++) target.push(source[i]);
+  return target;
+}
+
 function mergeParsedDocuments(docs, opts = {}) {
   const documents = Array.isArray(docs) ? docs : [];
   const scopeBlankNodes = typeof opts.scopeBlankNodes === 'boolean' ? opts.scopeBlankNodes : documents.length > 1;
@@ -15671,10 +15679,10 @@ function mergeParsedDocuments(docs, opts = {}) {
     const doc = scopeBlankNodes ? scopeBlankNodesInDocument(originalDoc, i + 1) : originalDoc;
 
     mergePrefixEnvs(merged.prefixes, doc.prefixes);
-    merged.triples.push(...(doc.triples || []));
-    merged.frules.push(...(doc.frules || []));
-    merged.brules.push(...(doc.brules || []));
-    merged.logQueryRules.push(...(doc.logQueryRules || []));
+    appendAll(merged.triples, doc.triples);
+    appendAll(merged.frules, doc.frules);
+    appendAll(merged.brules, doc.brules);
+    appendAll(merged.logQueryRules, doc.logQueryRules);
 
     if (doc.usedPrefixes instanceof Set) {
       if (!(merged.usedPrefixes instanceof Set)) {

--- a/eyeling.js
+++ b/eyeling.js
@@ -15658,6 +15658,14 @@ function mergePrefixEnvs(target, source) {
   return target;
 }
 
+// push(...array) gives every element its own stack argument slot, so a document
+// with more than ~128k triples overflows V8's argument limit. Append in a loop.
+function appendAll(target, source) {
+  if (!source) return target;
+  for (let i = 0; i < source.length; i++) target.push(source[i]);
+  return target;
+}
+
 function mergeParsedDocuments(docs, opts = {}) {
   const documents = Array.isArray(docs) ? docs : [];
   const scopeBlankNodes = typeof opts.scopeBlankNodes === 'boolean' ? opts.scopeBlankNodes : documents.length > 1;
@@ -15671,10 +15679,10 @@ function mergeParsedDocuments(docs, opts = {}) {
     const doc = scopeBlankNodes ? scopeBlankNodesInDocument(originalDoc, i + 1) : originalDoc;
 
     mergePrefixEnvs(merged.prefixes, doc.prefixes);
-    merged.triples.push(...(doc.triples || []));
-    merged.frules.push(...(doc.frules || []));
-    merged.brules.push(...(doc.brules || []));
-    merged.logQueryRules.push(...(doc.logQueryRules || []));
+    appendAll(merged.triples, doc.triples);
+    appendAll(merged.frules, doc.frules);
+    appendAll(merged.brules, doc.brules);
+    appendAll(merged.logQueryRules, doc.logQueryRules);
 
     if (doc.usedPrefixes instanceof Set) {
       if (!(merged.usedPrefixes instanceof Set)) {

--- a/lib/multisource.js
+++ b/lib/multisource.js
@@ -303,6 +303,14 @@ function mergePrefixEnvs(target, source) {
   return target;
 }
 
+// push(...array) gives every element its own stack argument slot, so a document
+// with more than ~128k triples overflows V8's argument limit. Append in a loop.
+function appendAll(target, source) {
+  if (!source) return target;
+  for (let i = 0; i < source.length; i++) target.push(source[i]);
+  return target;
+}
+
 function mergeParsedDocuments(docs, opts = {}) {
   const documents = Array.isArray(docs) ? docs : [];
   const scopeBlankNodes = typeof opts.scopeBlankNodes === 'boolean' ? opts.scopeBlankNodes : documents.length > 1;
@@ -316,10 +324,10 @@ function mergeParsedDocuments(docs, opts = {}) {
     const doc = scopeBlankNodes ? scopeBlankNodesInDocument(originalDoc, i + 1) : originalDoc;
 
     mergePrefixEnvs(merged.prefixes, doc.prefixes);
-    merged.triples.push(...(doc.triples || []));
-    merged.frules.push(...(doc.frules || []));
-    merged.brules.push(...(doc.brules || []));
-    merged.logQueryRules.push(...(doc.logQueryRules || []));
+    appendAll(merged.triples, doc.triples);
+    appendAll(merged.frules, doc.frules);
+    appendAll(merged.brules, doc.brules);
+    appendAll(merged.logQueryRules, doc.logQueryRules);
 
     if (doc.usedPrefixes instanceof Set) {
       if (!(merged.usedPrefixes instanceof Set)) {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -259,6 +259,41 @@ ${U('c')} ${U('friend')} ${U('d')}.
 
 const cases = [
   {
+    name: '00x a single document larger than the argument limit still loads',
+    // mergeParsedDocuments appended with push(...doc.triples), which gives every
+    // triple its own stack argument slot and overflowed past ~128k. Run through
+    // the CLI with a file: an input this size cannot be passed as an argument.
+    run() {
+      const os = require('node:os');
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'eyeling-large-doc-'));
+      const docPath = path.join(tmp, 'large.n3');
+
+      const lines = ['@prefix : <http://example.org/> .', '{ :n0 :par ?Y } => { :n0 :tc ?Y } .'];
+      for (let i = 0; i < 150000; i++) lines.push(`:n${i} :par :n${i + 1} .`);
+      fs.writeFileSync(docPath, lines.join('\n') + '\n', 'utf8');
+
+      try {
+        const r = spawnSync(process.execPath, [path.join(ROOT, 'eyeling.js'), docPath], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+          maxBuffer: DEFAULT_MAX_BUFFER,
+        });
+        if (r.error) throw r.error;
+        if (r.status !== 0) {
+          const err = new Error(`CLI failed with exit ${r.status}: ${r.stderr}`);
+          err.code = r.status;
+          throw err;
+        }
+        return r.stdout;
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+    check(out) {
+      assert.match(String(out), /:n0\s+:tc\s+:n1\s*\./);
+    },
+  },
+  {
     name: '00z duplicate detection is value equality, verified per fact',
     opt: { proofComments: false },
     input: `


### PR DESCRIPTION
- mergeParsedDocuments appended each source with push(...doc.triples), which gives every triple its own stack argument slot and overflows V8's argument limit past roughly 128k triples.
- a single 500k-triple N-Triples file failed to load at all with "Maximum call stack size exceeded". 

Append in a loop instead.