### PR TITLE
Do not retain derived facts in streaming mode (saving memory)

### DIFF
--- a/dist/browser/eyeling.browser.js
+++ b/dist/browser/eyeling.browser.js
@@ -6988,7 +6988,10 @@ function factsContainOutputStrings(triplesForOutput) {
           streamOut.write(rdfMode ? engine.tripleToRdfCompatible(df.fact, outPrefixes) : engine.tripleToN3(df.fact, outPrefixes));
         }
       },
-      { captureExplanations: engine.getProofCommentsEnabled(), prefixes: outPrefixes },
+      // The callback has already printed each triple and the return value is
+      // discarded, so retaining a record per derived fact serves nothing —
+      // streaming mode should be flat in output size, not just in latency.
+      { captureExplanations: engine.getProofCommentsEnabled(), collectDerived: false, prefixes: outPrefixes },
     );
     return;
   }

--- a/eyeling.js
+++ b/eyeling.js
@@ -6988,7 +6988,10 @@ function factsContainOutputStrings(triplesForOutput) {
           streamOut.write(rdfMode ? engine.tripleToRdfCompatible(df.fact, outPrefixes) : engine.tripleToN3(df.fact, outPrefixes));
         }
       },
-      { captureExplanations: engine.getProofCommentsEnabled(), prefixes: outPrefixes },
+      // The callback has already printed each triple and the return value is
+      // discarded, so retaining a record per derived fact serves nothing —
+      // streaming mode should be flat in output size, not just in latency.
+      { captureExplanations: engine.getProofCommentsEnabled(), collectDerived: false, prefixes: outPrefixes },
     );
     return;
   }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1274,7 +1274,10 @@ function factsContainOutputStrings(triplesForOutput) {
           streamOut.write(rdfMode ? engine.tripleToRdfCompatible(df.fact, outPrefixes) : engine.tripleToN3(df.fact, outPrefixes));
         }
       },
-      { captureExplanations: engine.getProofCommentsEnabled(), prefixes: outPrefixes },
+      // The callback has already printed each triple and the return value is
+      // discarded, so retaining a record per derived fact serves nothing —
+      // streaming mode should be flat in output size, not just in latency.
+      { captureExplanations: engine.getProofCommentsEnabled(), collectDerived: false, prefixes: outPrefixes },
     );
     return;
   }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -259,6 +259,41 @@ ${U('c')} ${U('friend')} ${U('d')}.
 
 const cases = [
   {
+    name: '00u collectDerived:false still reports every derived fact to onDerived',
+    // --stream prints from the callback and discards forwardChain's return value,
+    // so it asks for collectDerived:false. That is only safe while the callback
+    // still sees everything the collected array would have held.
+    run() {
+      const { forwardChain, parseN3Text: parseText } = require('../eyeling.js');
+      const N = 500;
+      const lines = ['@prefix : <http://example.org/> .', '{ ?X :par ?Y } => { ?X :tc ?Y } .'];
+      for (let i = 0; i < N; i++) lines.push(`:n${i} :par :m${i} .`);
+      const doc = parseText(lines.join('\n'), { keepSourceArtifacts: false });
+
+      const run = (collectDerived) => {
+        const seen = [];
+        const returned = forwardChain(doc.triples.slice(), doc.frules, doc.brules, (df) => seen.push(df.fact), {
+          captureExplanations: false,
+          collectDerived,
+          prefixes: doc.prefixes,
+        });
+        return { seen, returned };
+      };
+
+      const collected = run(true);
+      const streamed = run(false);
+
+      assert.equal(collected.seen.length, N, 'callback missed derivations when collecting');
+      assert.equal(streamed.seen.length, N, 'callback missed derivations when not collecting');
+      assert.equal(collected.returned.length, N, 'collectDerived:true should return every record');
+      assert.equal(streamed.returned.length, 0, 'collectDerived:false should retain nothing');
+      return 'ok';
+    },
+    check(out) {
+      assert.equal(out, 'ok');
+    },
+  },
+  {
     name: '00v buffered output is complete across chunk boundaries and matches --stream',
     // Default mode writes in chunks; streaming mode must not buffer at all. Both
     // have to emit every triple, so a dropped final flush or an off-by-one at a


### PR DESCRIPTION
`--stream` prints each triple from the forwardChain callback and discards the return value, but still asked the engine to collect a record per derived fact, so its memory grew with the output it had already written. 

Transitive closure over a random directed graph at 50k edges (1M derived) drops from 1056 MB to 475 MB, and a four-deep join over 50k facts from 590 MB to 474 MB. 

Output and time to first triple are unchanged.