### PR TITLE
Compact a solution without the reachability walk when it cannot help

### DIFF
--- a/dist/browser/eyeling.browser.js
+++ b/dist/browser/eyeling.browser.js
@@ -10159,6 +10159,12 @@ function gcCollectVarsInGoals(goals, out) {
   for (const g of goals) gcCollectVarsInTriple(g, out);
 }
 
+// An atomic term cannot contain a variable, so gcCollectVarsInTerm finds nothing
+// in it. Lists, open lists and quoted formulas can, and take the slow path.
+function __isAtomicBinding(t) {
+  return t instanceof Iri || t instanceof Literal || t instanceof Blank;
+}
+
 function gcCompactForGoals(subst, goals, answerVars) {
   const keep = new Set(answerVars);
   gcCollectVarsInGoals(goals, keep);
@@ -10381,9 +10387,27 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   if (opts && opts.keepVars) {
     for (const v of opts.keepVars) answerVars.add(v);
   }
+  const answerVarList = Array.from(answerVars);
+
+  // Every solution is compacted, so this is the hottest allocation in a
+  // saturating run. With no goals left the kept set is the answer variables plus
+  // any variables inside their bindings, so when every binding is atomic there
+  // is nothing to reach and the answer is just those bindings — no working sets,
+  // no reachability walk, no scan of the whole substitution.
+  function compactSolution() {
+    const out = __emptySubst();
+    for (let i = 0; i < answerVarList.length; i++) {
+      const v = answerVarList[i];
+      const bound = substMut[v];
+      if (bound === undefined) continue;
+      if (!__isAtomicBinding(bound)) return gcCompactForGoals(substMut, [], answerVars);
+      out[v] = bound;
+    }
+    return out;
+  }
 
   function emitSolution() {
-    const sol = gcCompactForGoals(substMut, [], answerVars);
+    const sol = compactSolution();
     produced++;
     if (!onSolution) {
       results.push(sol);

--- a/eyeling.js
+++ b/eyeling.js
@@ -10159,6 +10159,12 @@ function gcCollectVarsInGoals(goals, out) {
   for (const g of goals) gcCollectVarsInTriple(g, out);
 }
 
+// An atomic term cannot contain a variable, so gcCollectVarsInTerm finds nothing
+// in it. Lists, open lists and quoted formulas can, and take the slow path.
+function __isAtomicBinding(t) {
+  return t instanceof Iri || t instanceof Literal || t instanceof Blank;
+}
+
 function gcCompactForGoals(subst, goals, answerVars) {
   const keep = new Set(answerVars);
   gcCollectVarsInGoals(goals, keep);
@@ -10381,9 +10387,27 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   if (opts && opts.keepVars) {
     for (const v of opts.keepVars) answerVars.add(v);
   }
+  const answerVarList = Array.from(answerVars);
+
+  // Every solution is compacted, so this is the hottest allocation in a
+  // saturating run. With no goals left the kept set is the answer variables plus
+  // any variables inside their bindings, so when every binding is atomic there
+  // is nothing to reach and the answer is just those bindings — no working sets,
+  // no reachability walk, no scan of the whole substitution.
+  function compactSolution() {
+    const out = __emptySubst();
+    for (let i = 0; i < answerVarList.length; i++) {
+      const v = answerVarList[i];
+      const bound = substMut[v];
+      if (bound === undefined) continue;
+      if (!__isAtomicBinding(bound)) return gcCompactForGoals(substMut, [], answerVars);
+      out[v] = bound;
+    }
+    return out;
+  }
 
   function emitSolution() {
-    const sol = gcCompactForGoals(substMut, [], answerVars);
+    const sol = compactSolution();
     produced++;
     if (!onSolution) {
       results.push(sol);

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -2613,6 +2613,12 @@ function gcCollectVarsInGoals(goals, out) {
   for (const g of goals) gcCollectVarsInTriple(g, out);
 }
 
+// An atomic term cannot contain a variable, so gcCollectVarsInTerm finds nothing
+// in it. Lists, open lists and quoted formulas can, and take the slow path.
+function __isAtomicBinding(t) {
+  return t instanceof Iri || t instanceof Literal || t instanceof Blank;
+}
+
 function gcCompactForGoals(subst, goals, answerVars) {
   const keep = new Set(answerVars);
   gcCollectVarsInGoals(goals, keep);
@@ -2835,9 +2841,27 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   if (opts && opts.keepVars) {
     for (const v of opts.keepVars) answerVars.add(v);
   }
+  const answerVarList = Array.from(answerVars);
+
+  // Every solution is compacted, so this is the hottest allocation in a
+  // saturating run. With no goals left the kept set is the answer variables plus
+  // any variables inside their bindings, so when every binding is atomic there
+  // is nothing to reach and the answer is just those bindings — no working sets,
+  // no reachability walk, no scan of the whole substitution.
+  function compactSolution() {
+    const out = __emptySubst();
+    for (let i = 0; i < answerVarList.length; i++) {
+      const v = answerVarList[i];
+      const bound = substMut[v];
+      if (bound === undefined) continue;
+      if (!__isAtomicBinding(bound)) return gcCompactForGoals(substMut, [], answerVars);
+      out[v] = bound;
+    }
+    return out;
+  }
 
   function emitSolution() {
-    const sol = gcCompactForGoals(substMut, [], answerVars);
+    const sol = compactSolution();
     produced++;
     if (!onSolution) {
       results.push(sol);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -259,6 +259,54 @@ ${U('c')} ${U('friend')} ${U('d')}.
 
 const cases = [
   {
+    name: '00t solution compaction keeps list bindings intact',
+    // The fast path in emitSolution only handles bindings that cannot contain a
+    // variable. A list has to fall back to the reachability walk.
+    opt: { proofComments: false },
+    input: `
+@prefix : <http://example.org/> .
+:a :p (1 2 3) .
+{ ?X :p ?L } => { ?X :hasList ?L } .
+`,
+    check(out) {
+      assert.match(String(out), /:a\s+:hasList\s+\(1 2 3\)\s*\./);
+    },
+  },
+  {
+    name: '00t solution compaction keeps quoted-formula bindings intact',
+    opt: { proofComments: false },
+    input: `
+@prefix : <http://example.org/> .
+:a :says { :b :c :d } .
+{ ?X :says ?F } => { ?X :said ?F } .
+`,
+    check(out) {
+      assert.match(String(out), /:a\s+:said\s*\{/);
+      assert.match(String(out), /:b\s+:c\s+:d/);
+    },
+  },
+  {
+    name: '00t solution compaction keeps a variable reachable through a binding',
+    // ?L is bound to a list that still holds ?Y, so ?Y's own binding has to
+    // survive compaction for the head to instantiate.
+    opt: { proofComments: false },
+    input: `
+@prefix : <http://example.org/> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+:a :p :b .
+:a :p :c .
+{ ?X :p ?Y } => { ?X :seen ?Y } .
+{ ?X :seen ?Y . ?X :seen ?Z } => { ?X :pair (?Y ?Z) } .
+`,
+    check(out) {
+      const s = String(out);
+      assert.match(s, /:a\s+:pair\s+\(:b :b\)/);
+      assert.match(s, /:a\s+:pair\s+\(:b :c\)/);
+      assert.match(s, /:a\s+:pair\s+\(:c :b\)/);
+      assert.match(s, /:a\s+:pair\s+\(:c :c\)/);
+    },
+  },
+  {
     name: '00u collectDerived:false still reports every derived fact to onDerived',
     // --stream prints from the callback and discards forwardChain's return value,
     // so it asks for collectDerived:false. That is only safe while the callback


### PR DESCRIPTION
In openrulbench benchmarks it was detected that eyeling attemps millions of times to cleanup its scratchpad of variables. In many cases no such clean up is nesessary when the rule match variables are just plan names. This patch keeps a tally to check if something needs to clean up at all (nothing when only plain names are involved).

Details:

Every emitted solution was compacted by building two sets, running a reachability fixpoint over the bound terms and scanning the whole substitution — the hottest allocation in a saturating run. With no goals left the kept set is just the answer variables plus any variables inside their bindings, so when every binding is atomic there is nothing to reach and the bindings are the answer. Lists, open lists and quoted formulas still take the old path. Same generation at 5k goes 146.4s to 95.6s, transitive closure at 50k edges 190.6s to 131.4s, and a four-deep join over 50k facts 14.7s to 11.4s.