### PR TITLE
Stop a runaway backward proof at a limit instead of a V8 abort

### DIFF
--- a/dist/browser/eyeling.browser.js
+++ b/dist/browser/eyeling.browser.js
@@ -6555,6 +6555,7 @@ async function main() {
       `  -d, --deterministic-skolem   Make log:skolem stable across reasoning runs.\n` +
       `  -e, --enforce-https          Rewrite http:// IRIs to https:// for log dereferencing builtins.\n` +
       `  -h, --help                   Show this help and exit.\n` +
+      `      --max-frames <n>         Backward-proof search frame limit (default ${engine.DEFAULT_MAX_SEARCH_FRAMES}; 0 removes it).\n` +
       `  -p, --proof                  Enable proof explanations.\n` +
       `  -r, --rdf                    Enable RDF/TriG input/output compatibility.\n` +
       `      --stream-messages        Process RDF Message Logs one message at a time under -r.\n` +
@@ -6625,6 +6626,22 @@ async function main() {
       argv.__storePath = a.slice('--store-path='.length);
       continue;
     }
+    if (a === '--max-frames' || (typeof a === 'string' && a.startsWith('--max-frames='))) {
+      let value;
+      if (a === '--max-frames') {
+        value = argv[i + 1];
+        i += 1;
+      } else {
+        value = a.slice('--max-frames='.length);
+      }
+      const n = Number(value);
+      if (value === undefined || !Number.isFinite(n) || n < 0) {
+        console.error('Error: --max-frames expects a non-negative number (0 removes the limit).');
+        process.exit(1);
+      }
+      argv.__maxFrames = n;
+      continue;
+    }
     if (a === '--store-clear') continue;
     if (a === '-' || !a.startsWith('-')) positional.push(a);
   }
@@ -6650,6 +6667,12 @@ async function main() {
   // --proof / -p: enable proof explanations as N3 proof graphs
   if (argv.includes('--proof') || argv.includes('--proof-comments') || argv.includes('-p')) {
     engine.setProofCommentsEnabled(true);
+  }
+
+  // --max-frames: bound the backward prover so a goal that cannot terminate
+  // reports itself instead of being aborted by V8 on an out-of-memory.
+  if (typeof argv.__maxFrames === 'number' && typeof engine.setMaxSearchFrames === 'function') {
+    engine.setMaxSearchFrames(argv.__maxFrames);
   }
 
   // --super-restricted / -s: disable all builtins except => / <=
@@ -7581,6 +7604,18 @@ const {
 // forbidden condition provable, rather than a generic usage/runtime error.
 const INFERENCE_FUSE_EXIT_CODE = 65;
 
+// sysexits' EX_TEMPFAIL: the reasoner stopped at a limit of its own rather than
+// being killed, so a caller can tell "did not finish" from "crashed".
+const SEARCH_LIMIT_EXIT_CODE = 75;
+
+// A backward proof that does not terminate grows the search stack until V8
+// aborts on an out-of-memory, which is not catchable and says nothing useful.
+// Frame depth is the right thing to bound: it separates the two cases cleanly.
+// Measured over examples/, the deepest terminating proof is fibonacci at ~99k
+// frames, while a saturating forward run over 50k facts peaks at 3 — the depth
+// tracks the length of the resolution chain, not the size of the workload.
+const DEFAULT_MAX_SEARCH_FRAMES = 1000000;
+
 // In N3/Turtle, rdf:nil is the canonical IRI for the empty RDF list.
 // Eyeling represents list literals with ListTerm; ensure rdf:nil unifies with ().
 const RDF_NIL_IRI = RDF_NS + 'nil';
@@ -8423,6 +8458,7 @@ function __computeConclusionFromFormula(formula) {
 let proofCommentsEnabled = false;
 // Super restricted mode: disable *all* builtins except => / <= (log:implies / log:impliedBy)
 let superRestrictedMode = false;
+let maxSearchFrames = DEFAULT_MAX_SEARCH_FRAMES;
 
 // Initialize builtin evaluation (implemented in lib/builtins.js).
 const { evalBuiltin, isBuiltinPred } = makeBuiltins({
@@ -10402,6 +10438,25 @@ function __deltaSkipAhead(candidates, offset, deltaMin) {
   return exactLen + __lowerBoundPos(candidates.wild, offset - exactLen + 1, candidates.wildLen, deltaMin);
 }
 
+// A goal that cannot terminate is reported here rather than left to V8, which
+// aborts on the out-of-memory with a native stack trace and no goal in it.
+function __exitSearchLimit(limit, frame) {
+  const goal = frame && frame.goal0 ? frame.goal0 : frame && frame.goalsNow && frame.goalsNow[0];
+  let where = '';
+  if (goal) {
+    try {
+      where = `\n  deepest goal: ${tripleToN3(goal, __defaultFusePrefixEnv())}`;
+    } catch {
+      where = '';
+    }
+  }
+  const msg =
+    `Backward proof exceeded ${limit} search frames — it is not making progress toward an answer.${where}\n` +
+    '  Raise the limit with --max-frames N, or pass 0 to remove it.';
+  if (typeof console !== 'undefined' && console && typeof console.error === 'function') console.error(msg);
+  __exitReasoning(SEARCH_LIMIT_EXIT_CODE, msg);
+}
+
 // With opts.onSolution the caller takes each solution as it is found and gets back
 // the count, so an answer set is never held as an array. Callers that omit it get
 // the array and behave exactly as before.
@@ -10444,6 +10499,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   let memoBuf = onSolution ? [] : null;
 
   const factsLimit = __factsLimitOf(facts);
+  const frameLimit = maxSearchFrames;
 
   // IMPORTANT: Goal reordering / deferral is only enabled when explicitly
   // requested by the caller (used for forward rules).
@@ -10805,6 +10861,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   });
 
   while (stack.length && produced < max) {
+    if (stack.length > frameLimit) __exitSearchLimit(frameLimit, stack[stack.length - 1]);
     const frame = stack.pop();
 
     if (frame.kind === 'undo') {
@@ -12516,6 +12573,16 @@ function getSuperRestrictedMode() {
   return superRestrictedMode;
 }
 
+function getMaxSearchFrames() {
+  return maxSearchFrames;
+}
+
+// 0, or anything not a positive finite number, removes the limit.
+function setMaxSearchFrames(v) {
+  const n = typeof v === 'number' ? v : Number(v);
+  maxSearchFrames = Number.isFinite(n) && n > 0 ? Math.floor(n) : Infinity;
+}
+
 function setSuperRestrictedMode(v) {
   superRestrictedMode = !!v;
 }
@@ -12568,6 +12635,10 @@ module.exports = {
   loadBuiltinModule,
   listBuiltinIris,
   INFERENCE_FUSE_EXIT_CODE,
+  SEARCH_LIMIT_EXIT_CODE,
+  DEFAULT_MAX_SEARCH_FRAMES,
+  getMaxSearchFrames,
+  setMaxSearchFrames,
   createFactStore,
   MemoryFactStore,
   PersistentFactStore,

--- a/eyeling.js
+++ b/eyeling.js
@@ -6555,6 +6555,7 @@ async function main() {
       `  -d, --deterministic-skolem   Make log:skolem stable across reasoning runs.\n` +
       `  -e, --enforce-https          Rewrite http:// IRIs to https:// for log dereferencing builtins.\n` +
       `  -h, --help                   Show this help and exit.\n` +
+      `      --max-frames <n>         Backward-proof search frame limit (default ${engine.DEFAULT_MAX_SEARCH_FRAMES}; 0 removes it).\n` +
       `  -p, --proof                  Enable proof explanations.\n` +
       `  -r, --rdf                    Enable RDF/TriG input/output compatibility.\n` +
       `      --stream-messages        Process RDF Message Logs one message at a time under -r.\n` +
@@ -6625,6 +6626,22 @@ async function main() {
       argv.__storePath = a.slice('--store-path='.length);
       continue;
     }
+    if (a === '--max-frames' || (typeof a === 'string' && a.startsWith('--max-frames='))) {
+      let value;
+      if (a === '--max-frames') {
+        value = argv[i + 1];
+        i += 1;
+      } else {
+        value = a.slice('--max-frames='.length);
+      }
+      const n = Number(value);
+      if (value === undefined || !Number.isFinite(n) || n < 0) {
+        console.error('Error: --max-frames expects a non-negative number (0 removes the limit).');
+        process.exit(1);
+      }
+      argv.__maxFrames = n;
+      continue;
+    }
     if (a === '--store-clear') continue;
     if (a === '-' || !a.startsWith('-')) positional.push(a);
   }
@@ -6650,6 +6667,12 @@ async function main() {
   // --proof / -p: enable proof explanations as N3 proof graphs
   if (argv.includes('--proof') || argv.includes('--proof-comments') || argv.includes('-p')) {
     engine.setProofCommentsEnabled(true);
+  }
+
+  // --max-frames: bound the backward prover so a goal that cannot terminate
+  // reports itself instead of being aborted by V8 on an out-of-memory.
+  if (typeof argv.__maxFrames === 'number' && typeof engine.setMaxSearchFrames === 'function') {
+    engine.setMaxSearchFrames(argv.__maxFrames);
   }
 
   // --super-restricted / -s: disable all builtins except => / <=
@@ -7581,6 +7604,18 @@ const {
 // forbidden condition provable, rather than a generic usage/runtime error.
 const INFERENCE_FUSE_EXIT_CODE = 65;
 
+// sysexits' EX_TEMPFAIL: the reasoner stopped at a limit of its own rather than
+// being killed, so a caller can tell "did not finish" from "crashed".
+const SEARCH_LIMIT_EXIT_CODE = 75;
+
+// A backward proof that does not terminate grows the search stack until V8
+// aborts on an out-of-memory, which is not catchable and says nothing useful.
+// Frame depth is the right thing to bound: it separates the two cases cleanly.
+// Measured over examples/, the deepest terminating proof is fibonacci at ~99k
+// frames, while a saturating forward run over 50k facts peaks at 3 — the depth
+// tracks the length of the resolution chain, not the size of the workload.
+const DEFAULT_MAX_SEARCH_FRAMES = 1000000;
+
 // In N3/Turtle, rdf:nil is the canonical IRI for the empty RDF list.
 // Eyeling represents list literals with ListTerm; ensure rdf:nil unifies with ().
 const RDF_NIL_IRI = RDF_NS + 'nil';
@@ -8423,6 +8458,7 @@ function __computeConclusionFromFormula(formula) {
 let proofCommentsEnabled = false;
 // Super restricted mode: disable *all* builtins except => / <= (log:implies / log:impliedBy)
 let superRestrictedMode = false;
+let maxSearchFrames = DEFAULT_MAX_SEARCH_FRAMES;
 
 // Initialize builtin evaluation (implemented in lib/builtins.js).
 const { evalBuiltin, isBuiltinPred } = makeBuiltins({
@@ -10402,6 +10438,25 @@ function __deltaSkipAhead(candidates, offset, deltaMin) {
   return exactLen + __lowerBoundPos(candidates.wild, offset - exactLen + 1, candidates.wildLen, deltaMin);
 }
 
+// A goal that cannot terminate is reported here rather than left to V8, which
+// aborts on the out-of-memory with a native stack trace and no goal in it.
+function __exitSearchLimit(limit, frame) {
+  const goal = frame && frame.goal0 ? frame.goal0 : frame && frame.goalsNow && frame.goalsNow[0];
+  let where = '';
+  if (goal) {
+    try {
+      where = `\n  deepest goal: ${tripleToN3(goal, __defaultFusePrefixEnv())}`;
+    } catch {
+      where = '';
+    }
+  }
+  const msg =
+    `Backward proof exceeded ${limit} search frames — it is not making progress toward an answer.${where}\n` +
+    '  Raise the limit with --max-frames N, or pass 0 to remove it.';
+  if (typeof console !== 'undefined' && console && typeof console.error === 'function') console.error(msg);
+  __exitReasoning(SEARCH_LIMIT_EXIT_CODE, msg);
+}
+
 // With opts.onSolution the caller takes each solution as it is found and gets back
 // the count, so an answer set is never held as an array. Callers that omit it get
 // the array and behave exactly as before.
@@ -10444,6 +10499,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   let memoBuf = onSolution ? [] : null;
 
   const factsLimit = __factsLimitOf(facts);
+  const frameLimit = maxSearchFrames;
 
   // IMPORTANT: Goal reordering / deferral is only enabled when explicitly
   // requested by the caller (used for forward rules).
@@ -10805,6 +10861,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   });
 
   while (stack.length && produced < max) {
+    if (stack.length > frameLimit) __exitSearchLimit(frameLimit, stack[stack.length - 1]);
     const frame = stack.pop();
 
     if (frame.kind === 'undo') {
@@ -12516,6 +12573,16 @@ function getSuperRestrictedMode() {
   return superRestrictedMode;
 }
 
+function getMaxSearchFrames() {
+  return maxSearchFrames;
+}
+
+// 0, or anything not a positive finite number, removes the limit.
+function setMaxSearchFrames(v) {
+  const n = typeof v === 'number' ? v : Number(v);
+  maxSearchFrames = Number.isFinite(n) && n > 0 ? Math.floor(n) : Infinity;
+}
+
 function setSuperRestrictedMode(v) {
   superRestrictedMode = !!v;
 }
@@ -12568,6 +12635,10 @@ module.exports = {
   loadBuiltinModule,
   listBuiltinIris,
   INFERENCE_FUSE_EXIT_CODE,
+  SEARCH_LIMIT_EXIT_CODE,
+  DEFAULT_MAX_SEARCH_FRAMES,
+  getMaxSearchFrames,
+  setMaxSearchFrames,
   createFactStore,
   MemoryFactStore,
   PersistentFactStore,

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ function reason(opt = {}, input = '') {
   }
   if (opt.storePath) args.push('--store-path', String(opt.storePath));
   if (opt.storeClear) args.push('--store-clear');
+  if (opt.maxFrames !== undefined) args.push('--max-frames', String(opt.maxFrames));
 
   if (Array.isArray(opt.args)) args.push(...opt.args);
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -841,6 +841,7 @@ async function main() {
       `  -d, --deterministic-skolem   Make log:skolem stable across reasoning runs.\n` +
       `  -e, --enforce-https          Rewrite http:// IRIs to https:// for log dereferencing builtins.\n` +
       `  -h, --help                   Show this help and exit.\n` +
+      `      --max-frames <n>         Backward-proof search frame limit (default ${engine.DEFAULT_MAX_SEARCH_FRAMES}; 0 removes it).\n` +
       `  -p, --proof                  Enable proof explanations.\n` +
       `  -r, --rdf                    Enable RDF/TriG input/output compatibility.\n` +
       `      --stream-messages        Process RDF Message Logs one message at a time under -r.\n` +
@@ -911,6 +912,22 @@ async function main() {
       argv.__storePath = a.slice('--store-path='.length);
       continue;
     }
+    if (a === '--max-frames' || (typeof a === 'string' && a.startsWith('--max-frames='))) {
+      let value;
+      if (a === '--max-frames') {
+        value = argv[i + 1];
+        i += 1;
+      } else {
+        value = a.slice('--max-frames='.length);
+      }
+      const n = Number(value);
+      if (value === undefined || !Number.isFinite(n) || n < 0) {
+        console.error('Error: --max-frames expects a non-negative number (0 removes the limit).');
+        process.exit(1);
+      }
+      argv.__maxFrames = n;
+      continue;
+    }
     if (a === '--store-clear') continue;
     if (a === '-' || !a.startsWith('-')) positional.push(a);
   }
@@ -936,6 +953,12 @@ async function main() {
   // --proof / -p: enable proof explanations as N3 proof graphs
   if (argv.includes('--proof') || argv.includes('--proof-comments') || argv.includes('-p')) {
     engine.setProofCommentsEnabled(true);
+  }
+
+  // --max-frames: bound the backward prover so a goal that cannot terminate
+  // reports itself instead of being aborted by V8 on an out-of-memory.
+  if (typeof argv.__maxFrames === 'number' && typeof engine.setMaxSearchFrames === 'function') {
+    engine.setMaxSearchFrames(argv.__maxFrames);
   }
 
   // --super-restricted / -s: disable all builtins except => / <=

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -35,6 +35,18 @@ const {
 // forbidden condition provable, rather than a generic usage/runtime error.
 const INFERENCE_FUSE_EXIT_CODE = 65;
 
+// sysexits' EX_TEMPFAIL: the reasoner stopped at a limit of its own rather than
+// being killed, so a caller can tell "did not finish" from "crashed".
+const SEARCH_LIMIT_EXIT_CODE = 75;
+
+// A backward proof that does not terminate grows the search stack until V8
+// aborts on an out-of-memory, which is not catchable and says nothing useful.
+// Frame depth is the right thing to bound: it separates the two cases cleanly.
+// Measured over examples/, the deepest terminating proof is fibonacci at ~99k
+// frames, while a saturating forward run over 50k facts peaks at 3 — the depth
+// tracks the length of the resolution chain, not the size of the workload.
+const DEFAULT_MAX_SEARCH_FRAMES = 1000000;
+
 // In N3/Turtle, rdf:nil is the canonical IRI for the empty RDF list.
 // Eyeling represents list literals with ListTerm; ensure rdf:nil unifies with ().
 const RDF_NIL_IRI = RDF_NS + 'nil';
@@ -877,6 +889,7 @@ function __computeConclusionFromFormula(formula) {
 let proofCommentsEnabled = false;
 // Super restricted mode: disable *all* builtins except => / <= (log:implies / log:impliedBy)
 let superRestrictedMode = false;
+let maxSearchFrames = DEFAULT_MAX_SEARCH_FRAMES;
 
 // Initialize builtin evaluation (implemented in lib/builtins.js).
 const { evalBuiltin, isBuiltinPred } = makeBuiltins({
@@ -2856,6 +2869,25 @@ function __deltaSkipAhead(candidates, offset, deltaMin) {
   return exactLen + __lowerBoundPos(candidates.wild, offset - exactLen + 1, candidates.wildLen, deltaMin);
 }
 
+// A goal that cannot terminate is reported here rather than left to V8, which
+// aborts on the out-of-memory with a native stack trace and no goal in it.
+function __exitSearchLimit(limit, frame) {
+  const goal = frame && frame.goal0 ? frame.goal0 : frame && frame.goalsNow && frame.goalsNow[0];
+  let where = '';
+  if (goal) {
+    try {
+      where = `\n  deepest goal: ${tripleToN3(goal, __defaultFusePrefixEnv())}`;
+    } catch {
+      where = '';
+    }
+  }
+  const msg =
+    `Backward proof exceeded ${limit} search frames — it is not making progress toward an answer.${where}\n` +
+    '  Raise the limit with --max-frames N, or pass 0 to remove it.';
+  if (typeof console !== 'undefined' && console && typeof console.error === 'function') console.error(msg);
+  __exitReasoning(SEARCH_LIMIT_EXIT_CODE, msg);
+}
+
 // With opts.onSolution the caller takes each solution as it is found and gets back
 // the count, so an answer set is never held as an array. Callers that omit it get
 // the array and behave exactly as before.
@@ -2898,6 +2930,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   let memoBuf = onSolution ? [] : null;
 
   const factsLimit = __factsLimitOf(facts);
+  const frameLimit = maxSearchFrames;
 
   // IMPORTANT: Goal reordering / deferral is only enabled when explicitly
   // requested by the caller (used for forward rules).
@@ -3259,6 +3292,7 @@ function proveGoals(goals, subst, facts, backRules, depth, visited, varGen, maxR
   });
 
   while (stack.length && produced < max) {
+    if (stack.length > frameLimit) __exitSearchLimit(frameLimit, stack[stack.length - 1]);
     const frame = stack.pop();
 
     if (frame.kind === 'undo') {
@@ -4970,6 +5004,16 @@ function getSuperRestrictedMode() {
   return superRestrictedMode;
 }
 
+function getMaxSearchFrames() {
+  return maxSearchFrames;
+}
+
+// 0, or anything not a positive finite number, removes the limit.
+function setMaxSearchFrames(v) {
+  const n = typeof v === 'number' ? v : Number(v);
+  maxSearchFrames = Number.isFinite(n) && n > 0 ? Math.floor(n) : Infinity;
+}
+
 function setSuperRestrictedMode(v) {
   superRestrictedMode = !!v;
 }
@@ -5022,6 +5066,10 @@ module.exports = {
   loadBuiltinModule,
   listBuiltinIris,
   INFERENCE_FUSE_EXIT_CODE,
+  SEARCH_LIMIT_EXIT_CODE,
+  DEFAULT_MAX_SEARCH_FRAMES,
+  getMaxSearchFrames,
+  setMaxSearchFrames,
   createFactStore,
   MemoryFactStore,
   PersistentFactStore,

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -323,6 +323,58 @@ const cases = [
     },
   },
   {
+    name: '00r a backward proof that cannot terminate stops at its own limit (expect exit 75)',
+    // Right-recursive tc over a 2-cycle with a bound object. Without a limit the
+    // search stack grows until V8 aborts on an out-of-memory, which is not
+    // catchable and reports nothing useful.
+    opt: { proofComments: false, maxFrames: 3000 },
+    input: `
+@prefix : <http://example.org/> .
+:n1 :par :n2 .
+:n2 :par :n1 .
+{ ?X :tc ?Y } <= { ?X :par ?Y } .
+{ ?X :tc ?Y } <= { ?X :par ?Z . ?Z :tc ?Y } .
+{ ?X :tc :n1 } => { ?X :found :n1 } .
+`,
+    expectErrorCode: 75,
+  },
+  {
+    name: '00r the frame limit does not fire on a proof that terminates',
+    // Depth, not work: this recurses far enough to answer and stays well inside
+    // a limit that the diverging program above blows through immediately.
+    opt: { proofComments: false, maxFrames: 3000 },
+    input: `
+@prefix : <http://example.org/> .
+:n1 :par :n2 .
+:n2 :par :n3 .
+:n3 :par :n4 .
+{ ?X :tc ?Y } <= { ?X :par ?Y } .
+{ ?X :tc ?Y } <= { ?X :par ?Z . ?Z :tc ?Y } .
+{ :n1 :tc ?Y } => { :n1 :reaches ?Y } .
+`,
+    check(out) {
+      const s = String(out);
+      assert.match(s, /:n1\s+:reaches\s+:n2\s*\./);
+      assert.match(s, /:n1\s+:reaches\s+:n3\s*\./);
+      assert.match(s, /:n1\s+:reaches\s+:n4\s*\./);
+    },
+  },
+  {
+    name: '00r maxFrames 0 removes the limit',
+    opt: { proofComments: false, maxFrames: 0 },
+    input: `
+@prefix : <http://example.org/> .
+:n1 :par :n2 .
+:n2 :par :n3 .
+{ ?X :tc ?Y } <= { ?X :par ?Y } .
+{ ?X :tc ?Y } <= { ?X :par ?Z . ?Z :tc ?Y } .
+{ :n1 :tc ?Y } => { :n1 :reaches ?Y } .
+`,
+    check(out) {
+      assert.match(String(out), /:n1\s+:reaches\s+:n3\s*\./);
+    },
+  },
+  {
     name: '00t solution compaction keeps list bindings intact',
     // The fast path in emitSolution only handles bindings that cannot contain a
     // variable. A list has to fall back to the reachability walk.


### PR DESCRIPTION
A backward proof that cannot terminate grew the search stack until V8 aborted on  an out-of-memory. That abort is not catchable and its stack trace names no goal, so there was nothing to debug. The prover now bounds that stack and reports itself instead: it prints the goal it was deepest in and exits 75, the conventional "stopped at a limit of my own" code.

The limit is on frame depth, not on work done, because the two are unrelated: the deepest proof in examples/ is fibonacci at ~99k frames, while a forward run over 50k facts peaks at 3. The default of 1000000 leaves plenty of room. --max-frames N changes it, 0 removes it and restores the old behaviour. The check is one integer compare per step and costs nothing measurable.